### PR TITLE
#77 Carousel Alignment Bug

### DIFF
--- a/src/Tickets/show.js
+++ b/src/Tickets/show.js
@@ -170,8 +170,7 @@ export default class EventsTicket extends Component {
                 renderItem={this._renderItem}
                 sliderWidth={fullWidth}
                 itemWidth={itemWidth}
-                // containerCustomStyle={styles.slider}
-                // contentContainerCustomStyle={styles.sliderContentContainer}
+                slideStyle={ticketShowStyles.slideWrapper}
                 onSnapToItem={(index) => this.setState({activeSlide: index})}
               />
               <Pagination

--- a/src/styles/tickets/ticketShowStyles.js
+++ b/src/styles/tickets/ticketShowStyles.js
@@ -56,10 +56,13 @@ export const closeModalHeaderSize = 21
 
 const TicketShowStyles = {
   modalContainer: {
+    flexDirection: 'column',
     height: fullHeight,
+    justifyContent: 'center',
     paddingHorizontal: globalPadding,
   },
   modalBkgdImage: {
+    height: fullHeight,
     width: fullWidth,
     position: 'absolute',
   },
@@ -74,12 +77,10 @@ const TicketShowStyles = {
     fontFamily: globalFontMedium,
     fontSize: closeModalHeaderSize,
   },
-  // carouselContainer: {
-  //   alignItems: 'center',
-  //   flexDirection: 'column',
-  //   justifyContent: 'center',
-  //   height: fullHeight,
-  // },
+  slideWrapper: {
+    flexDirection: 'column',
+    justifyContent: 'center',
+  },
   details: {
     fontFamily: globalFontRegular,
     fontSize: bodyFontSize,


### PR DESCRIPTION
Connected to #77

- Put in container flex updates and custom carousel updates after reading through the docs to align the carousel in the center of the device no matter what height the device is (the issue was found on an iPhone X but it's now fixed on all devices)
- Checked on other device sizes and everything looks good
- Once this is merged I may get Brad to check on an Andriod (I don't have access to testing on Andriods right now, I can check when I'm in the office tomorrow if not)

<img width="324" alt="screen shot 2018-08-29 at 2 34 57 pm" src="https://user-images.githubusercontent.com/14582709/44812251-58ed6180-ab9c-11e8-8d80-642d4e170492.png">
<img width="324" alt="screen shot 2018-08-29 at 2 40 53 pm" src="https://user-images.githubusercontent.com/14582709/44812253-58ed6180-ab9c-11e8-8987-49706f848271.png">



