### PR TITLE
#92 Location Dropdown Alignment Bug

### DIFF
--- a/src/styles/shared/sharedStyles.js
+++ b/src/styles/shared/sharedStyles.js
@@ -233,7 +233,6 @@ const SharedStyles = {
     color: primaryColor,
     fontSize: iconFontSize,
     paddingRight: globalPaddingTiny,
-    paddingTop: globalPaddingTiny - 2,
   },
   iconLinkText: {
     color: primaryColor,
@@ -256,8 +255,8 @@ const SharedStyles = {
     height: 30,
   },
   iconImageSmall: {
-    width: 23,
-    height: 23,
+    width: 20,
+    height: 20,
     marginRight: globalPaddingTiny,
   },
 


### PR DESCRIPTION
Connected to #92 

- Fixed the alignment of the location link on the main Discover screen

<img width="341" alt="screen shot 2018-09-11 at 12 42 06 pm" src="https://user-images.githubusercontent.com/14582709/45379245-20e71500-b5c5-11e8-97e5-856beede29c1.png">
<img width="345" alt="screen shot 2018-09-11 at 12 45 47 pm" src="https://user-images.githubusercontent.com/14582709/45379246-20e71500-b5c5-11e8-837d-7f69cc18dac7.png">
