### PR TITLE
#100 Favicon Active State

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,14 +3,14 @@
     "sdkVersion": "27.0.0",
     "name": "Big Neon",
     "icon": "./assets/appIcon.png",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "slug": "revelrylabs-big-neon",
     "ios": {
       "bundleIdentifier": "com.revelrylabs.bigneon"
     },
     "android": {
       "package": "com.revelrylabs.bigneon",
-      "versionCode": 4
+      "versionCode": 5
     }
   }
 }

--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -46,8 +46,8 @@ export default class EventShow extends Component {
                   }}
                 />
                 <View style={eventDetailsStyles.videoActionsContainer}>
-                  <View style={styles.iconLinkCircleContainer}>
-                    <Icon style={styles.iconLinkCircle} name="star" />
+                  <View style={styles.iconLinkCircleContainerActive}>
+                    <Icon style={styles.iconLinkCircleActive} name="star" />
                   </View>
                   <View style={[styles.iconLinkCircleContainer, styles.marginTopSmall]}>
                     <Icon style={styles.iconLinkCircle} name="reply" />

--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -57,7 +57,7 @@ export default class EventShow extends Component {
                   }}
                 />
                 <View style={eventDetailsStyles.videoActionsContainer}>
-                  <TouchableHighlight onPress={() => this.toggleFavorite(!favorite)}>
+                  <TouchableHighlight underlayColor="rgba(0, 0, 0, 0)" onPress={() => this.toggleFavorite(!favorite)}>
                     <View style={favorite ? styles.iconLinkCircleContainer : styles.iconLinkCircleContainerActive}>
                       <Icon style={favorite ? styles.iconLinkCircle : styles.iconLinkCircleActive} name="star" />
                     </View>

--- a/src/styles/shared/sharedStyles.js
+++ b/src/styles/shared/sharedStyles.js
@@ -38,7 +38,7 @@ export const headerFontSize = 36
 export const sectionHeaderFontSize = 21
 export const bodyFontSize = 16
 export const iconFontSize = 18
-export const iconCircleFontSize = 26
+export const iconCircleFontSize = 25
 
 const SharedStyles = {
   // CONTAINERS
@@ -248,6 +248,17 @@ const SharedStyles = {
   },
   iconLinkCircle: {
     color: white,
+    fontSize: iconCircleFontSize,
+  },
+  iconLinkCircleContainerActive: {
+    backgroundColor: white,
+    borderRadius: 100/2,
+    height: 45,
+    padding: globalPaddingSmall,
+    width: 45,
+  },
+  iconLinkCircleActive: {
+    color: primaryColor,
     fontSize: iconCircleFontSize,
   },
   iconImage: {


### PR DESCRIPTION
Connected to #100 

- Added the active state styles to the favorite icon
- Assigning to @blazebarsamian for a design review, then passing to @daybreaker to set up functionality

**Note to @daybreaker:**
All I've done is add the active state styles, for example: 
inactive state classes: `iconLinkCircleContainer` and `iconLinkCircle`
active state classes: `iconLinkCircleContainerActive` and `iconLinkCircleActive`
I went ahead and added the active state styles in `/Events/show.js` so you can start there. I'm pretty sure there are other instances of the favorite icon, but the rest is covered in #101 

![simulator screen shot - iphone 7 - 2018-09-18 at 17 21 33](https://user-images.githubusercontent.com/14582709/45719971-09310300-bb68-11e8-8205-0e72becd3311.png)
