### PR TITLE
#101 Favorite Small Active State

### DIFF
--- a/src/Events/index.js
+++ b/src/Events/index.js
@@ -36,8 +36,8 @@ function EventItemView({
 
         <View style={eventStyles.detailsContainer}>
           <View style={eventStyles.sectionTop}>
-            <View style={eventStyles.iconLinkCircleContainerSmall}>
-              <Icon style={eventStyles.iconLinkCircleSmall} name="star" />
+            <View style={eventStyles.iconLinkCircleContainerSmallActive}>
+              <Icon style={eventStyles.iconLinkCircleSmallActive} name="star" />
             </View>
             <View style={styles.avatarContainer}>
               {avatarImages.map((source, key) => <Image style={styles.avatarSmall} source={source} key={key} />)}

--- a/src/styles/shared/eventStyles.js
+++ b/src/styles/shared/eventStyles.js
@@ -1,5 +1,6 @@
 import {
   white,
+  primaryColor,
   textColor,
   sectionHeaderFontSize,
   bodyFontSize,
@@ -63,7 +64,18 @@ const EventStyles = {
     color: white,
     fontSize: iconFontSize,
   },
-
+  iconLinkCircleContainerSmallActive: {
+    backgroundColor: white,
+    borderRadius: 100/2,
+    height: 28,
+    padding: globalPaddingTiny,
+    width: 28,
+  },
+  iconLinkCircleSmallActive: {
+    color: primaryColor,
+    fontSize: iconFontSize,
+  },
+  
   // IMAGE BKGD STYLES
   eventImage: {
     height: 180,


### PR DESCRIPTION
Connected to #101 

- Added the active state styling to the smaller favorite icons on the main Discover page
- larger favorite icon active styling is being covered in #100 

I'm going to go ahead and get @blazebarsamian to review and merge so this will be ready for @daybreaker to work once we get to this ticket in an upcoming sprint

![simulator screen shot - iphone 7 - 2018-09-19 at 10 35 54](https://user-images.githubusercontent.com/14582709/45765215-1dbddb80-bbfa-11e8-9842-378a0e103b4a.png)
