### PR TITLE
#102 Get Ticket Screen Styling

### DIFF
--- a/src/Events/checkout.js
+++ b/src/Events/checkout.js
@@ -1,0 +1,17 @@
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
+import {Text, View, TouchableHighlight} from 'react-native'
+
+export default class Checkout extends Component {
+  static propTypes = {
+    navigation: PropTypes.object,
+  }
+
+  render() {
+    return (
+      <View>
+        <Text>Checkout</Text>
+      </View>
+    )
+  }
+}

--- a/src/Events/index.js
+++ b/src/Events/index.js
@@ -235,7 +235,23 @@ export default class EventsIndex extends Component {
               disabled
             />
           </View>
+          <TouchableHighlight underlayColor="#fff" onPress={() => navigate('GetTickets')}>
+            <Text>
+              Get Tickets
+            </Text>
+          </TouchableHighlight>
 
+          <TouchableHighlight underlayColor="#fff" onPress={() => navigate('Checkout')}>
+            <Text>
+              Checkout
+            </Text>
+          </TouchableHighlight>
+
+          <TouchableHighlight underlayColor="#fff" onPress={() => navigate('PaymentTypes')}>
+            <Text>
+              Payment Types
+            </Text>
+          </TouchableHighlight>
           <Text style={styles.sectionHeader}>Hot This Week</Text>
 
           <View style={slideshowStyles.slideshowContainer}>

--- a/src/Events/payments.js
+++ b/src/Events/payments.js
@@ -1,0 +1,17 @@
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
+import {Text, View, TouchableHighlight} from 'react-native'
+
+export default class PaymentTypes extends Component {
+  static propTypes = {
+    navigation: PropTypes.object,
+  }
+
+  render() {
+    return (
+      <View>
+        <Text>Payment Types</Text>
+      </View>
+    )
+  }
+}

--- a/src/Events/routes.js
+++ b/src/Events/routes.js
@@ -2,6 +2,10 @@ import EventsIndex from './index'
 import EventsShow from './show'
 import EventsChangeLocation from './location'
 import EventsSearch from './search'
+import GetTickets from './tickets'
+import Checkout from './checkout'
+import PaymentTypes from './payments'
+
 
 const EventsIndexRoute = {
   screen: EventsIndex,
@@ -14,7 +18,7 @@ const EventsIndexRoute = {
 const EventsShowRoute = {
   screen: EventsShow,
   navigationOptions: ({
-    navigation
+    navigation,
   }) => ({
     title: navigation.state.params.name,
   }),
@@ -31,7 +35,28 @@ const EventsChangeLocationRoute = {
 const EventsSearchRoute = {
   screen: EventsSearch,
   navigationOptions: {
-    title: 'Search for Events'
+    title: 'Search for Events',
+  },
+}
+
+const GetTicketsRoute = {
+  screen: GetTickets,
+  navigationOptions: {
+    title: 'Get Tickets',
+  },
+}
+
+const CheckoutRoute = {
+  screen: Checkout,
+  navigationOptions: {
+    title: 'Checkout',
+  },
+}
+
+const PaymentTypesRoute = {
+  screen: PaymentTypes,
+  navigationOptions: {
+    title: 'PaymentTypes',
   },
 }
 
@@ -40,7 +65,10 @@ const ROUTES = {
   EventsIndex: EventsIndexRoute,
   EventsShow: EventsShowRoute,
   EventsChangeLocation: EventsChangeLocationRoute,
-  EventsSearchRoute: EventsSearchRoute,
+  EventsSearch: EventsSearchRoute,
+  GetTickets: GetTicketsRoute,
+  Checkout: CheckoutRoute,
+  PaymentTypes: PaymentTypesRoute,
 }
 
 export default ROUTES

--- a/src/Events/tickets.js
+++ b/src/Events/tickets.js
@@ -17,7 +17,7 @@ export default class GetTickets extends Component {
 
   render() {
     return (
-      <ScrollView>
+      <ScrollView style={eventTicketStyles.fullHeightContainer}>
 
         <View style={styles.container}>
           <View style={styles.sectionHeaderContainer}>
@@ -31,6 +31,19 @@ export default class GetTickets extends Component {
               <Text style={eventTicketStyles.ticketPrice}>$35</Text>
               <View>
                 <Text style={eventTicketStyles.ticketHeader}>General Admission</Text>
+                <Text style={eventTicketStyles.ticketSubHeader}>Lorem ipsum dolor sit amet non lorem.</Text>
+              </View>
+            </View>
+            <Icon style={accountStyles.accountArrow} name="keyboard-arrow-right" />
+          </View>
+        </TouchableHighlight>
+
+        <TouchableHighlight>
+          <View style={eventTicketStyles.rowContainer}>
+            <View style={eventTicketStyles.row}>
+              <Text style={eventTicketStyles.ticketPrice}>$55</Text>
+              <View>
+                <Text style={eventTicketStyles.ticketHeader}>VIP</Text>
                 <Text style={eventTicketStyles.ticketSubHeader}>Lorem ipsum dolor sit amet non lorem.</Text>
               </View>
             </View>

--- a/src/Events/tickets.js
+++ b/src/Events/tickets.js
@@ -18,23 +18,26 @@ export default class GetTickets extends Component {
   render() {
     return (
       <ScrollView>
-        <View style={styles.container}>
 
+        <View style={styles.container}>
           <View style={styles.sectionHeaderContainer}>
             <Text style={styles.header}>Ticket Type</Text>
           </View>
-
-          <TouchableHighlight>
-            <View style={eventTicketStyles.rowContainer}>
-              <View style={eventTicketStyles.row}>
-                <Icon style={eventTicketStyles.ticketIcon} name="account-circle" />
-                <Text style={eventTicketStyles.ticketHeader}>Account</Text>
-              </View>
-              <Icon style={accountStyles.accountArrow} name="keyboard-arrow-right" />
-            </View>
-          </TouchableHighlight>
-
         </View>
+
+        <TouchableHighlight>
+          <View style={eventTicketStyles.rowContainer}>
+            <View style={eventTicketStyles.row}>
+              <Icon style={eventTicketStyles.ticketIcon} name="account-circle" />
+              <View>
+                <Text style={eventTicketStyles.ticketHeader}>General Admission</Text>
+                <Text style={eventTicketStyles.ticketSubHeader}>Lorem ipsum dolor sit amet non lorem.</Text>
+              </View>
+            </View>
+            <Icon style={accountStyles.accountArrow} name="keyboard-arrow-right" />
+          </View>
+        </TouchableHighlight>
+
       </ScrollView>
     )
   }

--- a/src/Events/tickets.js
+++ b/src/Events/tickets.js
@@ -2,8 +2,12 @@ import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import {Text, View, TouchableHighlight, ScrollView} from 'react-native'
 import SharedStyles from '../styles/shared/sharedStyles'
+import AccountStyles from '../styles/account/accountStyles'
+import EventTicketStyles from '../styles/shared/eventTicketStyles'
 
 const styles = SharedStyles.createStyles()
+const accountStyles = AccountStyles.createStyles()
+const eventTicketStyles = EventTicketStyles.createStyles()
 
 export default class GetTickets extends Component {
   static propTypes = {
@@ -14,10 +18,22 @@ export default class GetTickets extends Component {
     return (
       <ScrollView>
         <View style={styles.container}>
+
           <View style={styles.sectionHeaderContainer}>
             <Text style={styles.header}>Ticket Type</Text>
           </View>
-        </View>  
+
+          <TouchableHighlight>
+            <View style={eventTicketStyles.rowContainer}>
+              <View style={eventTicketStyles.row}>
+                <Icon style={eventTicketStyles.ticketIcon} name="account-circle" />
+                <Text style={eventTicketStyles.ticketHeader}>Account</Text>
+              </View>
+              <Icon style={accountStyles.accountArrow} name="keyboard-arrow-right" />
+            </View>
+          </TouchableHighlight>
+
+        </View>
       </ScrollView>
     )
   }

--- a/src/Events/tickets.js
+++ b/src/Events/tickets.js
@@ -1,0 +1,17 @@
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
+import {Text, View, TouchableHighlight} from 'react-native'
+
+export default class GetTickets extends Component {
+  static propTypes = {
+    navigation: PropTypes.object,
+  }
+
+  render() {
+    return (
+      <View>
+        <Text>Tickets</Text>
+      </View>
+    )
+  }
+}

--- a/src/Events/tickets.js
+++ b/src/Events/tickets.js
@@ -1,9 +1,10 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import {Text, View, TouchableHighlight, ScrollView} from 'react-native'
+import Icon from 'react-native-vector-icons/MaterialIcons'
 import SharedStyles from '../styles/shared/sharedStyles'
 import AccountStyles from '../styles/account/accountStyles'
-import EventTicketStyles from '../styles/shared/eventTicketStyles'
+import EventTicketStyles from '../styles/event_details/eventTicketStyles'
 
 const styles = SharedStyles.createStyles()
 const accountStyles = AccountStyles.createStyles()

--- a/src/Events/tickets.js
+++ b/src/Events/tickets.js
@@ -1,6 +1,9 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
-import {Text, View, TouchableHighlight} from 'react-native'
+import {Text, View, TouchableHighlight, ScrollView} from 'react-native'
+import SharedStyles from '../styles/shared/sharedStyles'
+
+const styles = SharedStyles.createStyles()
 
 export default class GetTickets extends Component {
   static propTypes = {
@@ -9,9 +12,13 @@ export default class GetTickets extends Component {
 
   render() {
     return (
-      <View>
-        <Text>Tickets</Text>
-      </View>
+      <ScrollView>
+        <View style={styles.container}>
+          <View style={styles.sectionHeaderContainer}>
+            <Text style={styles.header}>Ticket Type</Text>
+          </View>
+        </View>  
+      </ScrollView>
     )
   }
 }

--- a/src/Events/tickets.js
+++ b/src/Events/tickets.js
@@ -28,7 +28,7 @@ export default class GetTickets extends Component {
         <TouchableHighlight>
           <View style={eventTicketStyles.rowContainer}>
             <View style={eventTicketStyles.row}>
-              <Icon style={eventTicketStyles.ticketIcon} name="account-circle" />
+              <Text style={eventTicketStyles.ticketPrice}>$35</Text>
               <View>
                 <Text style={eventTicketStyles.ticketHeader}>General Admission</Text>
                 <Text style={eventTicketStyles.ticketSubHeader}>Lorem ipsum dolor sit amet non lorem.</Text>

--- a/src/styles/event_details/eventTicketStyles.js
+++ b/src/styles/event_details/eventTicketStyles.js
@@ -21,6 +21,12 @@ export const ticketPriceFontSize = 32
 
 
 const EventTicketStyles = {
+  // CONTAINER STYLES
+  fullHeightContainer: {
+    backgroundColor: white,
+    height: fullHeight,
+  },
+
   // ROW STYLES
   rowContainer: {
     alignItems: 'center',
@@ -51,7 +57,7 @@ const EventTicketStyles = {
     fontSize: bodyFontSize,
   },
   ticketSubHeader: {
-    color: borderColor,
+    color: sectionHeaderColor,
     fontFamily: globalFontRegular,
     fontSize: bodyFontSize,
   },

--- a/src/styles/event_details/eventTicketStyles.js
+++ b/src/styles/event_details/eventTicketStyles.js
@@ -17,6 +17,8 @@ const fullWidth = Dimensions.get('window').width
 
 export const whiteTransparent = 'rgba(255, 255, 255, 0.8)'
 
+export const ticketPriceFontSize = 32
+
 
 const EventTicketStyles = {
   // ROW STYLES
@@ -36,11 +38,12 @@ const EventTicketStyles = {
     justifyContent: 'flex-start',
   },
 
-  // ACCOUNT SUBNAV STYLES
-  ticketIcon: {
-    color: sectionHeaderColor,
-    fontSize: bodyFontSize,
-    paddingRight: globalPaddingSmall,
+  // TICKET SUBNAV STYLES
+  ticketPrice: {
+    color: primaryColor,
+    fontFamily: globalFontSemiBold,
+    fontSize: ticketPriceFontSize,
+    paddingRight: globalPadding,
   },
   ticketHeader: {
     color: textColor,

--- a/src/styles/event_details/eventTicketStyles.js
+++ b/src/styles/event_details/eventTicketStyles.js
@@ -7,6 +7,7 @@ import {
   bodyFontSize,
   iconFontSize,
   globalFontRegular,
+  globalFontSemiBold,
   globalPadding,
   globalPaddingSmall,
 } from '../shared/sharedStyles'
@@ -27,7 +28,7 @@ const EventTicketStyles = {
     flexDirection: 'row',
     justifyContent: 'space-between',
     paddingHorizontal: globalPadding,
-    paddingVertical: globalPaddingSmall,
+    paddingVertical: globalPadding,
     width: fullWidth,
   },
   row: {
@@ -43,8 +44,13 @@ const EventTicketStyles = {
   },
   ticketHeader: {
     color: textColor,
+    fontFamily: globalFontSemiBold,
+    fontSize: bodyFontSize,
+  },
+  ticketSubHeader: {
+    color: borderColor,
     fontFamily: globalFontRegular,
-    fontSize: iconFontSize,
+    fontSize: bodyFontSize,
   },
 }
 

--- a/src/styles/event_details/eventTicketStyles.js
+++ b/src/styles/event_details/eventTicketStyles.js
@@ -1,0 +1,48 @@
+import {
+  primaryColor,
+} from '../shared/sharedStyles'
+import {StyleSheet, Dimensions, Platform} from 'react-native'
+const fullHeight = Dimensions.get('window').height
+const fullWidth = Dimensions.get('window').width
+
+export const whiteTransparent = 'rgba(255, 255, 255, 0.8)'
+
+
+const EventTicketStyles = {
+  // ROW STYLES
+  rowContainer: {
+    alignItems: 'center',
+    backgroundColor: white,
+    borderBottomColor: borderColor,
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: globalPadding,
+    paddingVertical: globalPaddingSmall,
+    width: fullWidth,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+  },
+
+  // ACCOUNT SUBNAV STYLES
+  ticketIcon: {
+    color: sectionHeaderColor,
+    fontSize: bodyFontSize,
+    paddingRight: globalPaddingSmall,
+  },
+  ticketHeader: {
+    color: textColor,
+    fontFamily: globalFontRegular,
+    fontSize: iconFontSize,
+  },
+}
+
+function createStyles(overrides = {}) {
+  return StyleSheet.create({...EventTicketStyles, ...overrides})
+}
+
+export default {
+  createStyles,
+}

--- a/src/styles/event_details/eventTicketStyles.js
+++ b/src/styles/event_details/eventTicketStyles.js
@@ -1,5 +1,14 @@
 import {
+  white,
   primaryColor,
+  sectionHeaderColor,
+  borderColor,
+  textColor,
+  bodyFontSize,
+  iconFontSize,
+  globalFontRegular,
+  globalPadding,
+  globalPaddingSmall,
 } from '../shared/sharedStyles'
 import {StyleSheet, Dimensions, Platform} from 'react-native'
 const fullHeight = Dimensions.get('window').height


### PR DESCRIPTION
Connected to #102

- Stubbed out the Get Ticket Screen according to the latest mocks
- We still need to set up the scrolling section animation/modal to set up on this page, but the ticket selection styling is complete in this PR

**Note**:
This is branched off of the `sections` branch where @daybreaker set up each individual screen

<img width="330" alt="screen shot 2018-09-25 at 3 11 02 pm" src="https://user-images.githubusercontent.com/14582709/46040306-8662f780-c0d5-11e8-8d7f-df02af7b2040.png">
