### PR TITLE
#119 Location Alignment Bug

### DIFF
--- a/src/Events/index.js
+++ b/src/Events/index.js
@@ -229,7 +229,7 @@ export default class EventsIndex extends Component {
               renderSeparator={() => <View />}
               dropdownStyle={modalStyles.modalDropdownContainer}
             >
-              <View style={styles.iconLinkContainer}>
+              <View style={styles.dropdownLinkContainer}>
                 <Image
                   style={styles.iconImageSmall}
                   source={require('../../assets/heart-small.png')}

--- a/src/styles/shared/sharedStyles.js
+++ b/src/styles/shared/sharedStyles.js
@@ -234,6 +234,11 @@ const SharedStyles = {
     alignItems: 'flex-start',
     flexDirection: 'row',
   },
+  dropdownLinkContainer: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
   iconLink: {
     backgroundColor: 'transparent',
     color: primaryColor,
@@ -275,6 +280,7 @@ const SharedStyles = {
     width: 18,
     height: 18,
     marginRight: globalPaddingTiny,
+    marginTop: -2,
   },
 
   // PRICE TAG STYLES

--- a/src/styles/shared/sharedStyles.js
+++ b/src/styles/shared/sharedStyles.js
@@ -272,8 +272,8 @@ const SharedStyles = {
     height: 30,
   },
   iconImageSmall: {
-    width: 20,
-    height: 20,
+    width: 18,
+    height: 18,
     marginRight: globalPaddingTiny,
   },
 


### PR DESCRIPTION
Connected to #119 

- Fixed the alignment issue on the Location Dropdown on the main Explore homepage
- Pulled the new screenshot into Sketch to measure and make sure everything was aligned correctly

Before:
![46079165-f7e58900-c15b-11e8-8983-c94ef1cd3b48](https://user-images.githubusercontent.com/14582709/46313724-34ffb000-c58e-11e8-8315-2fb76e2efd48.jpg)

After:
![simulator screen shot - iphone x - 2018-10-01 at 15 20 59](https://user-images.githubusercontent.com/14582709/46313737-3cbf5480-c58e-11e8-977b-fef9ff13b586.png)

Screenshot of Sketch grid measurements:
<img width="1165" alt="screen shot 2018-10-01 at 3 22 31 pm" src="https://user-images.githubusercontent.com/14582709/46313765-4fd22480-c58e-11e8-945a-e7ac830644f0.png">
