### PR TITLE
#124 Favorite/Close Button Overlap Bug

### DIFF
--- a/src/Events/details.js
+++ b/src/Events/details.js
@@ -126,7 +126,7 @@ export default class Details extends Component {
             <Text style={eventDetailsStyles.iconSectionHeader}>YOUTUBE</Text>
           </View>
 
-          <View style={eventDetailsStyles.videoContainer}>
+          <View style={eventDetailsStyles.youtubeVideoContainer}>
             <Image
               style={eventDetailsStyles.videoBkgd}
               source={require('../../assets/video-youtube-bkgd.png')}

--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -160,7 +160,6 @@ export default class EventShow extends Component {
           style={eventDetailsStyles.videoBkgd}
           source={require('../../assets/video-bkgd.png')}
         />
-        <View style={eventDetailsStyles.spacer} />
 
         <ScrollView>
           {this.showScreen}

--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -156,32 +156,36 @@ export default class EventShow extends Component {
 
     return (
       <View style={{backgroundColor: 'white'}}>
-        <View style={[eventDetailsStyles.videoContainer, eventDetailsStyles.videoContainerHeader]}>
+        <View style={[eventDetailsStyles.videoContainer, eventDetailsStyles.videoHeaderContainer]}>
           <Image
             style={eventDetailsStyles.videoBkgd}
             source={require('../../assets/video-bkgd.png')}
           />
         </View>
+
         <ScrollView>
           {this.showScreen}
         </ScrollView>
-        <View style={[eventDetailsStyles.videoDetailsContainer, eventDetailsStyles.videoContainerHeader]}>
 
-          <View style={eventDetailsStyles.sectionTop}>
+        <View style={eventDetailsStyles.videoHeaderContainer}>
+
+          <View style={eventDetailsStyles.backArrowContainer}>
             {this.backArrow}
-            <View style={eventDetailsStyles.videoActionsContainer}>
-              <TouchableHighlight underlayColor="rgba(0, 0, 0, 0)" onPress={() => this.toggleFavorite(!favorite)}>
-                <View style={favorite ? styles.iconLinkCircleContainerActive : styles.iconLinkCircleContainer}>
-                  <Icon style={favorite ? styles.iconLinkCircleActive : styles.iconLinkCircle} name="star" />
-                </View>
-              </TouchableHighlight>
-              <View style={[styles.iconLinkCircleContainer, styles.marginTopSmall]}>
-                <Icon style={styles.iconLinkCircle} name="reply" />
+          </View>
+
+          <View style={eventDetailsStyles.videoActionsContainer}>
+            <TouchableHighlight underlayColor="rgba(0, 0, 0, 0)" onPress={() => this.toggleFavorite(!favorite)}>
+              <View style={favorite ? styles.iconLinkCircleContainerActive : styles.iconLinkCircleContainer}>
+                <Icon style={favorite ? styles.iconLinkCircleActive : styles.iconLinkCircle} name="star" />
               </View>
+            </TouchableHighlight>
+            <View style={[styles.iconLinkCircleContainer, styles.marginTopSmall]}>
+              <Icon style={styles.iconLinkCircle} name="reply" />
             </View>
           </View>
 
         </View>
+
 
 
         {this.getTickets}

--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -143,11 +143,13 @@ export default class EventShow extends Component {
     const icon = currentScreen === 'details' ? 'close' : 'arrow-back'
 
     return (
-      <Icon
-        style={eventDetailsStyles.backArrow}
-        name={icon}
-        onPress={() => this.prevScreen}
-      />
+      <View style={eventDetailsStyles.backArrowCircleContainer}>
+        <Icon
+          style={eventDetailsStyles.backArrow}
+          name={icon}
+          onPress={() => this.prevScreen}
+        />
+      </View>
     )
   }
 

--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -156,37 +156,34 @@ export default class EventShow extends Component {
 
     return (
       <View style={{backgroundColor: 'white'}}>
-        <View style={[eventDetailsStyles.videoContainer, eventDetailsStyles.videoHeaderContainer]}>
-          <Image
-            style={eventDetailsStyles.videoBkgd}
-            source={require('../../assets/video-bkgd.png')}
-          />
-        </View>
+        <Image
+          style={eventDetailsStyles.videoBkgd}
+          source={require('../../assets/video-bkgd.png')}
+        />
+        <View style={eventDetailsStyles.spacer} />
 
         <ScrollView>
           {this.showScreen}
         </ScrollView>
 
-        <View style={eventDetailsStyles.videoHeaderContainer}>
 
-          <View style={eventDetailsStyles.backArrowWrapper}>
-            {this.backArrow}
-          </View>
+        <View style={eventDetailsStyles.backArrowWrapper}>
+          {this.backArrow}
+        </View>
 
-          <View style={eventDetailsStyles.videoActionsWrapper}>
-            <View style={styles.flexColumnFlexStart}>
-              <TouchableHighlight underlayColor="rgba(0, 0, 0, 0)" onPress={() => this.toggleFavorite(!favorite)}>
-                <View style={favorite ? styles.iconLinkCircleContainerActive : styles.iconLinkCircleContainer}>
-                  <Icon style={favorite ? styles.iconLinkCircleActive : styles.iconLinkCircle} name="star" />
-                </View>
-              </TouchableHighlight>
-              <View style={[styles.iconLinkCircleContainer, styles.marginTopSmall]}>
-                <Icon style={styles.iconLinkCircle} name="reply" />
+        <View style={eventDetailsStyles.videoActionsWrapper}>
+          <View style={styles.flexColumnFlexStart}>
+            <TouchableHighlight underlayColor="rgba(0, 0, 0, 0)" onPress={() => this.toggleFavorite(!favorite)}>
+              <View style={favorite ? styles.iconLinkCircleContainerActive : styles.iconLinkCircleContainer}>
+                <Icon style={favorite ? styles.iconLinkCircleActive : styles.iconLinkCircle} name="star" />
               </View>
+            </TouchableHighlight>
+            <View style={[styles.iconLinkCircleContainer, styles.marginTopSmall]}>
+              <Icon style={styles.iconLinkCircle} name="reply" />
             </View>
           </View>
-
         </View>
+
 
 
 

--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -161,30 +161,28 @@ export default class EventShow extends Component {
             style={eventDetailsStyles.videoBkgd}
             source={require('../../assets/video-bkgd.png')}
           />
+        </View>
+        <ScrollView>
+          {this.showScreen}
+        </ScrollView>
+        <View style={[eventDetailsStyles.videoDetailsContainer, eventDetailsStyles.videoContainerHeader]}>
 
-          <View style={eventDetailsStyles.videoDetailsContainer}>
-
-            <View style={eventDetailsStyles.sectionTop}>
-              {this.backArrow}
-              <View style={eventDetailsStyles.videoActionsContainer}>
-                <TouchableHighlight underlayColor="rgba(0, 0, 0, 0)" onPress={() => this.toggleFavorite(!favorite)}>
-                  <View style={favorite ? styles.iconLinkCircleContainerActive : styles.iconLinkCircleContainer}>
-                    <Icon style={favorite ? styles.iconLinkCircleActive : styles.iconLinkCircle} name="star" />
-                  </View>
-                </TouchableHighlight>
-                <View style={[styles.iconLinkCircleContainer, styles.marginTopSmall]}>
-                  <Icon style={styles.iconLinkCircle} name="reply" />
+          <View style={eventDetailsStyles.sectionTop}>
+            {this.backArrow}
+            <View style={eventDetailsStyles.videoActionsContainer}>
+              <TouchableHighlight underlayColor="rgba(0, 0, 0, 0)" onPress={() => this.toggleFavorite(!favorite)}>
+                <View style={favorite ? styles.iconLinkCircleContainerActive : styles.iconLinkCircleContainer}>
+                  <Icon style={favorite ? styles.iconLinkCircleActive : styles.iconLinkCircle} name="star" />
                 </View>
+              </TouchableHighlight>
+              <View style={[styles.iconLinkCircleContainer, styles.marginTopSmall]}>
+                <Icon style={styles.iconLinkCircle} name="reply" />
               </View>
             </View>
-
           </View>
 
         </View>
 
-        <ScrollView>
-          {this.showScreen}
-        </ScrollView>
 
         {this.getTickets}
       </View>

--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -144,7 +144,7 @@ export default class EventShow extends Component {
 
     return (
       <Icon
-        style={styles.iconLinkCircle}
+        style={eventDetailsStyles.backArrow}
         name={icon}
         onPress={() => this.prevScreen}
       />
@@ -169,18 +169,20 @@ export default class EventShow extends Component {
 
         <View style={eventDetailsStyles.videoHeaderContainer}>
 
-          <View style={eventDetailsStyles.backArrowContainer}>
+          <View style={eventDetailsStyles.backArrowWrapper}>
             {this.backArrow}
           </View>
 
-          <View style={eventDetailsStyles.videoActionsContainer}>
-            <TouchableHighlight underlayColor="rgba(0, 0, 0, 0)" onPress={() => this.toggleFavorite(!favorite)}>
-              <View style={favorite ? styles.iconLinkCircleContainerActive : styles.iconLinkCircleContainer}>
-                <Icon style={favorite ? styles.iconLinkCircleActive : styles.iconLinkCircle} name="star" />
+          <View style={eventDetailsStyles.videoActionsWrapper}>
+            <View style={styles.flexColumnFlexStart}>
+              <TouchableHighlight underlayColor="rgba(0, 0, 0, 0)" onPress={() => this.toggleFavorite(!favorite)}>
+                <View style={favorite ? styles.iconLinkCircleContainerActive : styles.iconLinkCircleContainer}>
+                  <Icon style={favorite ? styles.iconLinkCircleActive : styles.iconLinkCircle} name="star" />
+                </View>
+              </TouchableHighlight>
+              <View style={[styles.iconLinkCircleContainer, styles.marginTopSmall]}>
+                <Icon style={styles.iconLinkCircle} name="reply" />
               </View>
-            </TouchableHighlight>
-            <View style={[styles.iconLinkCircleContainer, styles.marginTopSmall]}>
-              <Icon style={styles.iconLinkCircle} name="reply" />
             </View>
           </View>
 

--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -170,22 +170,6 @@ export default class EventShow extends Component {
           {this.backArrow}
         </View>
 
-        <View style={eventDetailsStyles.videoActionsWrapper}>
-          <View style={styles.flexColumnFlexStart}>
-            <TouchableHighlight underlayColor="rgba(0, 0, 0, 0)" onPress={() => this.toggleFavorite(!favorite)}>
-              <View style={favorite ? styles.iconLinkCircleContainerActive : styles.iconLinkCircleContainer}>
-                <Icon style={favorite ? styles.iconLinkCircleActive : styles.iconLinkCircle} name="star" />
-              </View>
-            </TouchableHighlight>
-            <View style={[styles.iconLinkCircleContainer, styles.marginTopSmall]}>
-              <Icon style={styles.iconLinkCircle} name="reply" />
-            </View>
-          </View>
-        </View>
-
-
-
-
         {this.getTickets}
       </View>
     )

--- a/src/styles/event_details/eventDetailsStyles.js
+++ b/src/styles/event_details/eventDetailsStyles.js
@@ -4,6 +4,7 @@ import {
   sectionHeaderColor,
   borderColor,
   textColor,
+  disabledHeaderColor,
   globalFontRegular,
   globalFontMedium,
   globalFontSemiBold,
@@ -30,7 +31,7 @@ export const calendarMonthFontSize = 14
 export const iconLargeFontSize = 56
 export const slideShowArrowFontSize = 28
 export const attendeeFontSize = 12
-export const backArrowFontSize = 38
+export const backArrowFontSize = 25
 
 const EventDetailsStyles = {
   // VIDEO BKGD STYLES
@@ -42,13 +43,20 @@ const EventDetailsStyles = {
     zIndex: -10,
   },
 
-  // VIDEO HEADER STYLES
+  // CLOSE ICON STYLES
   backArrowWrapper: {
     position: 'absolute',
     top: 0,
     padding: globalPaddingSmall,
     paddingTop: globalPaddingLarge,
     zIndex: 0,
+  },
+  backArrowCircleContainer: {
+    backgroundColor: disabledHeaderColor,
+    borderRadius: 100/2,
+    height: 45,
+    padding: globalPaddingSmall,
+    width: 45,
   },
   backArrow: {
     color: white,

--- a/src/styles/event_details/eventDetailsStyles.js
+++ b/src/styles/event_details/eventDetailsStyles.js
@@ -31,7 +31,7 @@ export const slideShowArrowFontSize = 28
 export const attendeeFontSize = 12
 
 const EventDetailsStyles = {
-  // VIDEO STYLES
+  // VIDEO BKGD STYLES
   videoContainer: {
     flex: 1,
     flexDirection: 'column',
@@ -39,24 +39,28 @@ const EventDetailsStyles = {
     alignItems: 'center',
     height: 300,
   },
-  videoContainerHeader: {
-    position: 'absolute',
-    top: 0,
-    width: fullWidth,
-  },
   videoBkgd: {
     width: fullWidth,
     height: 300,
     position: 'absolute',
     top: 0,
   },
-  videoDetailsContainer: {
-    flexDirection: 'column',
-    height: 100,
-    justifyContent: 'space-between',
-    padding: globalPaddingSmall,
-    paddingTop: globalPaddingLarge,
+  // videoDetailsContainer: {
+  //   flexDirection: 'column',
+  //   height: 100,
+  //   justifyContent: 'space-between',
+  //   padding: globalPaddingSmall,
+  //   paddingTop: globalPaddingLarge,
+  //   width: fullWidth,
+  // },
+
+  // VIDEO HEADER ACTIONS STYLES
+  videoHeaderContainer: {
+    position: 'absolute',
+    top: 0,
     width: fullWidth,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
   },
 
   // MAIN BODY STYLES
@@ -82,23 +86,22 @@ const EventDetailsStyles = {
   },
 
   // CONTAINER STYLES
+  backArrowContainer: {
+
+  },
+  videoActionsContainer: {
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+  },
   fixedFooter: {
     position: 'absolute',
     bottom: 0,
-  },
-  sectionTop: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
   },
   sectionBottom: {
     alignItems: 'center',
     justifyContent: 'center',
     marginTop: -45,
     paddingBottom: globalPaddingLarge,
-  },
-  videoActionsContainer: {
-    flexDirection: 'row',
-    justifyContent: 'flex-start',
   },
   iconSectionHeaderContainer: {
     alignItems: 'center',

--- a/src/styles/event_details/eventDetailsStyles.js
+++ b/src/styles/event_details/eventDetailsStyles.js
@@ -42,15 +42,17 @@ const EventDetailsStyles = {
   videoContainerHeader: {
     position: 'absolute',
     top: 0,
+    width: fullWidth,
   },
   videoBkgd: {
     width: fullWidth,
     height: 300,
     position: 'absolute',
+    top: 0,
   },
   videoDetailsContainer: {
     flexDirection: 'column',
-    height: 290,
+    height: 100,
     justifyContent: 'space-between',
     padding: globalPaddingSmall,
     paddingTop: globalPaddingLarge,
@@ -95,7 +97,7 @@ const EventDetailsStyles = {
     paddingBottom: globalPaddingLarge,
   },
   videoActionsContainer: {
-    flexDirection: 'column',
+    flexDirection: 'row',
     justifyContent: 'flex-start',
   },
   iconSectionHeaderContainer: {

--- a/src/styles/event_details/eventDetailsStyles.js
+++ b/src/styles/event_details/eventDetailsStyles.js
@@ -48,7 +48,7 @@ const EventDetailsStyles = {
     top: 0,
     padding: globalPaddingSmall,
     paddingTop: globalPaddingLarge,
-    zIndex: -1,
+    zIndex: 0,
   },
   backArrow: {
     color: white,
@@ -63,7 +63,7 @@ const EventDetailsStyles = {
     position: 'absolute',
     top: 0,
     right: 0,
-    zIndex: -1,
+    zIndex: 0,
   },
 
   // MAIN BODY STYLES
@@ -72,10 +72,7 @@ const EventDetailsStyles = {
     paddingLeft: 0,
     paddingRight: 0,
     paddingHorizontal: 0,
-    // height: fullHeight - 240,
-    // flexDirection: 'column',
-    // justifyContent: 'flex-end',
-    // marginTop: 240,
+    marginTop: 240,
   },
   mainBodyContent: {
     backgroundColor: 'white',
@@ -84,12 +81,7 @@ const EventDetailsStyles = {
     paddingHorizontal: globalPadding,
     paddingTop: globalPaddingMedium,
     position: 'relative',
-    zIndex: 0,
-  },
-  spacer: {
-    height: 240,
-    position: 'relative',
-    zIndex: -100,
+    zIndex: 10,
   },
   spacerFooter: {
     height: 60,

--- a/src/styles/event_details/eventDetailsStyles.js
+++ b/src/styles/event_details/eventDetailsStyles.js
@@ -9,6 +9,7 @@ import {
   globalFontSemiBold,
   globalFontBold,
   bodyFontSize,
+  globalPaddingLarger,
   globalPaddingLarge,
   globalPaddingMedium,
   globalPadding,
@@ -33,53 +34,36 @@ export const backArrowFontSize = 38
 
 const EventDetailsStyles = {
   // VIDEO BKGD STYLES
-  videoContainer: {
-    flex: 1,
-    flexDirection: 'column',
-    justifyContent: 'center',
-    alignItems: 'center',
-    height: 300,
-  },
   videoBkgd: {
-    width: fullWidth,
     height: 300,
     position: 'absolute',
     top: 0,
+    width: fullWidth,
+    zIndex: -10,
   },
-  // videoDetailsContainer: {
-  //   flexDirection: 'column',
-  //   height: 100,
-  //   justifyContent: 'space-between',
-  //   padding: globalPaddingSmall,
-  //   paddingTop: globalPaddingLarge,
-  //   width: fullWidth,
-  // },
 
   // VIDEO HEADER STYLES
-  videoHeaderContainer: {
+  backArrowWrapper: {
     position: 'absolute',
     top: 0,
-    // width: fullWidth,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-  backArrowWrapper: {
     padding: globalPaddingSmall,
     paddingTop: globalPaddingLarge,
+    zIndex: -1,
   },
   backArrow: {
     color: white,
     fontSize: backArrowFontSize,
   },
   videoActionsWrapper: {
-    // flexDirection: 'column',
-    // justifyContent: 'flex-start',
     flex: 1,
-    alignItems: 'flex-end',
     flexDirection: 'row',
     justifyContent: 'flex-end',
     padding: globalPaddingSmall,
-    paddingTop: globalPaddingLarge,
+    paddingTop: globalPaddingLarger,
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    zIndex: -1,
   },
 
   // MAIN BODY STYLES
@@ -88,7 +72,10 @@ const EventDetailsStyles = {
     paddingLeft: 0,
     paddingRight: 0,
     paddingHorizontal: 0,
-    marginTop: 240,
+    // height: fullHeight - 240,
+    // flexDirection: 'column',
+    // justifyContent: 'flex-end',
+    // marginTop: 240,
   },
   mainBodyContent: {
     backgroundColor: 'white',
@@ -96,9 +83,13 @@ const EventDetailsStyles = {
     borderTopLeftRadius: 30/2,
     paddingHorizontal: globalPadding,
     paddingTop: globalPaddingMedium,
+    position: 'relative',
+    zIndex: 0,
   },
   spacer: {
-    height: 220,
+    height: 240,
+    position: 'relative',
+    zIndex: -100,
   },
   spacerFooter: {
     height: 60,
@@ -120,6 +111,13 @@ const EventDetailsStyles = {
     flexDirection: 'row',
     justifyContent: 'flex-start',
     paddingVertical: globalPadding,
+  },
+  youtubeVideoContainer: {
+    flex: 1,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: 300,
   },
 
   // TEXT STYLES

--- a/src/styles/event_details/eventDetailsStyles.js
+++ b/src/styles/event_details/eventDetailsStyles.js
@@ -54,17 +54,6 @@ const EventDetailsStyles = {
     color: white,
     fontSize: backArrowFontSize,
   },
-  videoActionsWrapper: {
-    flex: 1,
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    padding: globalPaddingSmall,
-    paddingTop: globalPaddingLarger,
-    position: 'absolute',
-    top: 0,
-    right: 0,
-    zIndex: 0,
-  },
 
   // MAIN BODY STYLES
   mainBody: {

--- a/src/styles/event_details/eventDetailsStyles.js
+++ b/src/styles/event_details/eventDetailsStyles.js
@@ -29,6 +29,7 @@ export const calendarMonthFontSize = 14
 export const iconLargeFontSize = 56
 export const slideShowArrowFontSize = 28
 export const attendeeFontSize = 12
+export const backArrowFontSize = 38
 
 const EventDetailsStyles = {
   // VIDEO BKGD STYLES
@@ -54,13 +55,31 @@ const EventDetailsStyles = {
   //   width: fullWidth,
   // },
 
-  // VIDEO HEADER ACTIONS STYLES
+  // VIDEO HEADER STYLES
   videoHeaderContainer: {
     position: 'absolute',
     top: 0,
-    width: fullWidth,
+    // width: fullWidth,
     flexDirection: 'row',
     justifyContent: 'space-between',
+  },
+  backArrowWrapper: {
+    padding: globalPaddingSmall,
+    paddingTop: globalPaddingLarge,
+  },
+  backArrow: {
+    color: white,
+    fontSize: backArrowFontSize,
+  },
+  videoActionsWrapper: {
+    // flexDirection: 'column',
+    // justifyContent: 'flex-start',
+    flex: 1,
+    alignItems: 'flex-end',
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    padding: globalPaddingSmall,
+    paddingTop: globalPaddingLarge,
   },
 
   // MAIN BODY STYLES
@@ -86,13 +105,6 @@ const EventDetailsStyles = {
   },
 
   // CONTAINER STYLES
-  backArrowContainer: {
-
-  },
-  videoActionsContainer: {
-    flexDirection: 'row',
-    justifyContent: 'flex-start',
-  },
   fixedFooter: {
     position: 'absolute',
     bottom: 0,

--- a/src/styles/shared/sharedStyles.js
+++ b/src/styles/shared/sharedStyles.js
@@ -403,6 +403,10 @@ const SharedStyles = {
     flexDirection: 'column',
     justifyContent: 'center',
   },
+  flexColumnFlexStart: {
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+  },
 
   // ROWS COLS
   row: {


### PR DESCRIPTION
Connected to #124 
Connected to #123 

Found solutions for the following issues that were discussed in the ticket:
- Removed Favorite buttons per new Sketch files
- Found a solution for the overlapping close button since hiding it behind the `ScrollView` hasn't been do-able with the current setup/positioned items on the screen
- Added close button in it's own View, so we can eliminate the issue with the container box blocking access to the `ScrollView` scrolling

**Important Notes**:
- Additional design updates for Event Page per the newest Sketch file will be covered in another ticket
- @daybreaker and I discussed how we will need to add a background overlay to the close button, since the bkgd img will be switched out later on and could be any color making it hard to see just the white icon

gif of latest screen updates:
![demo-large-3](https://user-images.githubusercontent.com/14582709/46379757-7616c380-c665-11e8-9543-a32f23e85ed4.gif)
