### PR TITLE
Location Selection Header bug

### DIFF
--- a/src/Events/eventStateProvider.js
+++ b/src/Events/eventStateProvider.js
@@ -89,10 +89,11 @@ class EventsContainer extends Container {
     };
   }
 
-  changeLocation = (_index, selectedLocation) => {
-    console.log("Yes were changing?", _index, selectedLocation);
-
-    this.setState({selectedLocationId: selectedLocation.id})
+  changeLocation = (index, selectedLocation) => {
+    if (index !== '0') {
+      this.setState({selectedLocationId: selectedLocation.id})
+    }
+    return null
   }
 }
 

--- a/src/Events/index.js
+++ b/src/Events/index.js
@@ -70,7 +70,7 @@ export default class EventsIndex extends Component {
   }
 
   locRowOption = (rowData, rowID, _highlighted) => {
-    if (rowID === 0) {
+    if (rowID === '0') {
       return (
         <View>
           <View style={modalStyles.rowWrapper}>


### PR DESCRIPTION
connects #153 

Fixes two bugs: 

- Header styling broken due to index checking for 0 instead of '0'
- Header was selectable after switching to Unstated container due to not ignoring selection of index '0' (header object)