### PR TITLE
Flushing a failed login

### DIFF
--- a/src/Accounts/account.js
+++ b/src/Accounts/account.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Text, View, Image, TextInput, ScrollView, TouchableHighlight, AsyncStorage} from 'react-native';
+import {Text, View, Image, TextInput, ScrollView, TouchableHighlight} from 'react-native';
 import SharedStyles from '../styles/shared/sharedStyles'
 import AccountStyles from '../styles/account/accountStyles'
 import TicketWalletStyles from '../styles/tickets/ticketWalletStyles'
@@ -8,14 +8,8 @@ const styles = SharedStyles.createStyles()
 const accountStyles = AccountStyles.createStyles()
 const ticketWalletStyles = TicketWalletStyles.createStyles()
 
-// @TODO: Switch this to use AuthContainer.logOut
-const signOutAsync = async ({navigate}) => {
-  await AsyncStorage.clear();
-  navigate;
-};
-
 export default function AccountDetails(props) {
-  const {navigation: {navigate}} = props
+  const {navigation: {navigate}, screenProps: {auth: {logOut}}} = props
 
   return (
     <ScrollView style={styles.containerDark}>
@@ -93,7 +87,7 @@ export default function AccountDetails(props) {
           <TouchableHighlight
             style={styles.buttonSecondary}
           >
-            <Text style={styles.buttonSecondaryText} onPress={() => signOutAsync(navigate('Auth'))}>Sign Out</Text>
+            <Text style={styles.buttonSecondaryText} onPress={() => logOut(navigate)}>Sign Out</Text>
           </TouchableHighlight>
         </View>
 

--- a/src/Accounts/index.js
+++ b/src/Accounts/index.js
@@ -1,19 +1,13 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types'
-import {ScrollView, Modal, Text, View, Image, TouchableHighlight, Button} from 'react-native';
+import {ScrollView, Modal, Text, View, Image, TouchableHighlight} from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import SharedStyles from '../styles/shared/sharedStyles'
 import AccountStyles from '../styles/account/accountStyles'
-import TicketStyles from '../styles/tickets/ticketStyles'
-import TicketWalletStyles from '../styles/tickets/ticketWalletStyles'
-import EventCardStyles from '../styles/shared/eventCardStyles'
 import ModalStyles from '../styles/shared/modalStyles'
 
 const styles = SharedStyles.createStyles()
 const accountStyles = AccountStyles.createStyles()
-const ticketStyles = TicketStyles.createStyles()
-const ticketWalletStyles = TicketWalletStyles.createStyles()
-const eventCardStyles = EventCardStyles.createStyles()
 const modalStyles = ModalStyles.createStyles()
 
 
@@ -23,7 +17,7 @@ const QRCode = ({_qrCode, toggleModal, modalVisible}) => (
       toggleModal(!modalVisible)
     }}
     visible={modalVisible}
-    transparent={true}
+    transparent
   >
     <View style={modalStyles.modalContainer}>
       <View style={modalStyles.contentWrapper}>
@@ -58,6 +52,7 @@ QRCode.propTypes = {
 export default class Account extends Component {
   static propTypes = {
     navigation: PropTypes.object.isRequired,
+    screenProps: PropTypes.object.isRequired,
   }
 
   constructor(props) {

--- a/src/Auth/AuthLoadingScreen.js
+++ b/src/Auth/AuthLoadingScreen.js
@@ -30,7 +30,7 @@ class AuthStore extends Component {
       const {state: {currentUser}} = auth
 
       if (Object.keys(currentUser).length === 0) {
-        await auth.getCurrentUser(userToken, refreshToken)
+        await auth.getCurrentUser(navigate, userToken, refreshToken)
       }
 
       navigate('App')

--- a/src/Auth/authStateProvider.js
+++ b/src/Auth/authStateProvider.js
@@ -9,11 +9,15 @@ class AuthContainer extends Container {
   constructor(props = {}) {
     super(props);
 
-    this.state = {
+    this.state = this.defaultState
+  }
+
+  get defaultState() {
+    return {
       currentUser: {},
       access_token: null,
       refresh_tokn: null,
-    };
+    }
   }
 
   // @TODO: Implement a login that also sets AsyncStgorage user
@@ -25,7 +29,7 @@ class AuthContainer extends Container {
 
       await AsyncStorage.setItem('userToken', access_token)
       await AsyncStorage.setItem('refreshToken', refresh_token)
-      await this.getCurrentUser(access_token, refresh_token, false)
+      await this.getCurrentUser(navigate, access_token, refresh_token, false)
       navigate('AuthLoading')
 
     } catch (error) {
@@ -35,14 +39,23 @@ class AuthContainer extends Container {
     }
   }
 
-  // logOut = async() => {
-  //   // clear asyncstorage and state
-  // }
+  logOut = async (navigate) => { // eslint-disable-line space-before-function-paren
+    await AsyncStorage.clear();
+    this.setState(this.defaultState, () => {
+      navigate('AuthLoading')
+    })
+  }
 
-  getCurrentUser = async (access_token, refresh_token, setToken = true) => { // eslint-disable-line space-before-function-paren
+  // eslint-disable-next-line complexity
+  getCurrentUser = async (navigate, access_token, refresh_token, setToken = true) => { // eslint-disable-line space-before-function-paren
     if (setToken) {
-      await server.client.setToken(access_token)
-      await server.auth.refresh({refresh_token})
+      try {
+        await server.client.setToken(access_token)
+        await server.auth.refresh({refresh_token})
+      } catch (error) {
+        console.log('TOKEN ERROR', error) // eslint-disable-line no-console
+        this.logOut(navigate)
+      }
     }
 
     try {
@@ -51,6 +64,7 @@ class AuthContainer extends Container {
       this.setState({currentUser: myUserResponse.data, access_token, refresh_token})
     } catch (error) {
       console.log('Set Current User Error', error); // eslint-disable-line no-console
+      this.logOut(navigate)
     }
   }
 


### PR DESCRIPTION
connects #192 #193 

Adds a logout method to the AuthContainer that flushes a stored login/refresh token and resets the currentUser prompting a new login.

This will trigger automatically on a failed token refresh attempt, or a failed attempt at setting the current user based on a token.

It is also used by the Account->SignOut button