### PR TITLE
#175 Account Profile - Make Full Text Inputs Selectable

### DIFF
--- a/src/Accounts/account.js
+++ b/src/Accounts/account.js
@@ -33,9 +33,8 @@ export default function AccountDetails(props) {
           <View style={accountStyles.row}>
             <Text style={accountStyles.accountInputHeaderDisabled}>First Name</Text>
             <TextInput
-              style={styles.flexColumnCenter}
               placeholder="Kook"
-              placeholderTextColor='black'
+              placeholderTextColor='gray'
             />
           </View>
         </View>
@@ -44,9 +43,8 @@ export default function AccountDetails(props) {
           <View style={accountStyles.row}>
             <Text style={accountStyles.accountInputHeaderDisabled}>Last Name</Text>
             <TextInput
-              style={styles.flexColumnCenter}
               placeholder="McDropin"
-              placeholderTextColor='black'
+              placeholderTextColor='gray'
             />
           </View>
         </View>
@@ -55,9 +53,8 @@ export default function AccountDetails(props) {
           <View style={accountStyles.row}>
             <Text style={accountStyles.accountInputHeaderDisabled}>Mobile</Text>
             <TextInput
-              style={styles.flexColumnCenter}
               placeholder="504-000-0000"
-              placeholderTextColor='black'
+              placeholderTextColor='gray'
             />
           </View>
         </View>
@@ -66,9 +63,8 @@ export default function AccountDetails(props) {
           <View style={accountStyles.row}>
             <Text style={accountStyles.accountInputHeaderDisabled}>Email</Text>
             <TextInput
-              style={styles.flexColumnCenter}
               placeholder="kookmcdropz@gmail.com"
-              placeholderTextColor='black'
+              placeholderTextColor='gray'
             />
           </View>
         </View>
@@ -77,9 +73,8 @@ export default function AccountDetails(props) {
           <View style={accountStyles.row}>
             <Text style={accountStyles.accountInputHeaderDisabled}>Password</Text>
             <TextInput
-              style={styles.flexColumnCenter}
               placeholder="password"
-              placeholderTextColor='black'
+              placeholderTextColor='gray'
             />
           </View>
         </View>

--- a/src/Accounts/account.js
+++ b/src/Accounts/account.js
@@ -29,52 +29,57 @@ export default function AccountDetails(props) {
           </View>
         </View>
 
-        <View style={accountStyles.rowContainer}>
+        <View style={accountStyles.inputContainer}>
           <View style={accountStyles.row}>
             <Text style={accountStyles.accountInputHeaderDisabled}>First Name</Text>
             <TextInput
+              style={accountStyles.accountInputHeader}
               placeholder="Kook"
-              placeholderTextColor='gray'
+              placeholderTextColor='#CCC'
             />
           </View>
         </View>
 
-        <View style={accountStyles.rowContainer}>
+        <View style={accountStyles.inputContainer}>
           <View style={accountStyles.row}>
             <Text style={accountStyles.accountInputHeaderDisabled}>Last Name</Text>
             <TextInput
+              style={accountStyles.accountInputHeader}
               placeholder="McDropin"
-              placeholderTextColor='gray'
+              placeholderTextColor='#CCC'
             />
           </View>
         </View>
 
-        <View style={[accountStyles.rowContainer, styles.marginTop]}>
+        <View style={[accountStyles.inputContainer, styles.marginTop]}>
           <View style={accountStyles.row}>
             <Text style={accountStyles.accountInputHeaderDisabled}>Mobile</Text>
             <TextInput
+              style={accountStyles.accountInputHeader}
               placeholder="504-000-0000"
-              placeholderTextColor='gray'
+              placeholderTextColor='#CCC'
             />
           </View>
         </View>
 
-        <View style={accountStyles.rowContainer}>
+        <View style={accountStyles.inputContainer}>
           <View style={accountStyles.row}>
             <Text style={accountStyles.accountInputHeaderDisabled}>Email</Text>
             <TextInput
+              style={accountStyles.accountInputHeader}
               placeholder="kookmcdropz@gmail.com"
-              placeholderTextColor='gray'
+              placeholderTextColor='#CCC'
             />
           </View>
         </View>
 
-        <View style={accountStyles.rowContainer}>
+        <View style={accountStyles.inputContainer}>
           <View style={accountStyles.row}>
             <Text style={accountStyles.accountInputHeaderDisabled}>Password</Text>
             <TextInput
+              style={accountStyles.accountInputHeader}
               placeholder="password"
-              placeholderTextColor='gray'
+              placeholderTextColor='#CCC'
             />
           </View>
         </View>

--- a/src/styles/account/accountStyles.js
+++ b/src/styles/account/accountStyles.js
@@ -6,6 +6,7 @@ import {
   borderColor,
   containerDarkColor,
   disabledHeaderColor,
+  disabledColor,
   bodyFontSize,
   iconFontSize,
   globalFontRegular,
@@ -153,9 +154,22 @@ const AccountStyles = {
   },
 
   // INPUT STYLES
+  inputContainer: {
+    alignItems: 'center',
+    backgroundColor: white,
+    borderBottomColor: borderColor,
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    height: 45,
+    justifyContent: 'space-between',
+    paddingHorizontal: globalPadding,
+    width: fullWidth,
+  },
   accountInputHeader: {
-    flexDirection: 'column',
-    justifyContent: 'center',
+    color: textColor,
+    fontFamily: globalFontRegular,
+    fontSize: iconFontSize,
+    width: fullWidth,
   },
   accountInputHeaderDisabled: {
     color: disabledHeaderColor,

--- a/src/styles/shared/formStyles.js
+++ b/src/styles/shared/formStyles.js
@@ -5,6 +5,7 @@ import {
   borderColor,
   searchIconColor,
   inputBackgroundColor,
+  disabledColor,
   globalFontRegular,
   globalFontSemiBold,
   iconFontSize,
@@ -18,8 +19,6 @@ import {
 import {StyleSheet, Dimensions, Platform} from 'react-native'
 const fullHeight = Dimensions.get('window').height
 const fullWidth = Dimensions.get('window').width
-
-export const disabledColor = '#F7F7F7'
 
 export const bodyFontSize = 18
 export const searchIconFontSize = 21

--- a/src/styles/shared/sharedStyles.js
+++ b/src/styles/shared/sharedStyles.js
@@ -17,6 +17,7 @@ export const containerDarkColor = '#F5F6F7'
 export const primaryTransparent = 'rgba(255, 34, 178, 0.5)'
 export const whiteTransparent = 'rgba(255, 255, 255, 0.3)'
 export const disabledHeaderColor = 'rgba(64, 64, 64, 0.5)'
+export const disabledColor = '#F7F7F7'
 
 export const globalPaddingTiny = 5
 export const globalPaddingSmall = 10


### PR DESCRIPTION
Connected to #175 

- Made the TextInputs selectable anywhere within the area by making a few design edits and giving them a fullWidth
- I also changed the placeholder text color so it can be distinguishable from the actual input text once it's inserted

**Things to break out into separate bug tickets:**
- The inputs don't actually save when you change anything (placeholders are always there). I see the mocks are updated to include a Save button so I'm assuming we will be creating a new ticket for these updates
- Billing Information screen needs to be updated (create new ticket)

![demo-large-3](https://user-images.githubusercontent.com/14582709/47458748-f7aecc80-d79f-11e8-966e-6b415d451c92.gif)
<img width="353" alt="screen shot 2018-10-24 at 3 14 42 pm" src="https://user-images.githubusercontent.com/14582709/47458749-f7aecc80-d79f-11e8-81f5-3e26ab2c323a.png">
