### PR TITLE
#283 Spacing Bug 

### DIFF
--- a/src/Events/index.js
+++ b/src/Events/index.js
@@ -270,6 +270,8 @@ export default class EventsIndex extends Component {
           <Text style={styles.sectionHeader}>Upcoming</Text>
 
           {this.allEvents}
+
+          <View style={styles.spacer} />
         </ScrollView>
         <Animated.View style={[navigationStyles.scrollHeaderContainer, {height: headerHeight, transform: [{translateY: headerTranslate}]}]}>
           <View style={navigationStyles.scrollHeader}>

--- a/src/Tickets/index.js
+++ b/src/Tickets/index.js
@@ -189,6 +189,8 @@ export default class MyTickets extends Component {
               purchasedTicketId={this.state.purchasedTicket}
             />
           </View>
+          
+          <View style={styles.spacer} />
 
         </ScrollView>
       </View>

--- a/src/navigators/appNavigator.js
+++ b/src/navigators/appNavigator.js
@@ -21,7 +21,7 @@ const tabBarOptions = {
       borderWidth: 0,
       borderTopColor: '#DCDCDC',
       height: 50,
-      paddingVertical: 3,
+      paddingVertical: 4,
     },
   },
 }

--- a/src/navigators/appNavigator.js
+++ b/src/navigators/appNavigator.js
@@ -13,8 +13,8 @@ const tabBarOptions = {
     activeTintColor: '#FF20B1',
     inactiveTintColor: 'black',
     labelStyle: {
-      fontFamily: 'tt_commons_demibold',
-      fontSize: 14,
+      fontFamily: 'tt_commons_regular',
+      fontSize: 13,
     },
     style: {
       backgroundColor: 'white',

--- a/src/styles/shared/sharedStyles.js
+++ b/src/styles/shared/sharedStyles.js
@@ -120,6 +120,9 @@ const SharedStyles = {
   section: {
     paddingVertical: globalPaddingLarge,
   },
+  spacer: {
+    height: 25,
+  },
 
   // BUTTONS
   buttonContainer: {

--- a/src/styles/shared/sharedStyles.js
+++ b/src/styles/shared/sharedStyles.js
@@ -70,7 +70,7 @@ const SharedStyles = {
     borderBottomWidth: 1,
     borderStyle: 'solid',
     paddingHorizontal: globalPadding,
-    paddingTop: globalPadding,
+    paddingTop: globalPaddingSmall,
     width: fullWidth,
     flexDirection: 'column',
   },


### PR DESCRIPTION
Connected to #283 

- Put in a spacing bug fix on the Explore Homepage and Ticket Wallet screens
- I had to add a spacer component in each instance because adding any top margin to the BottomNav itself won't work because it causes more overlap (it's a React Native Plugin)
- Made two small edits to the BottomNav text and TopBar on Ticket Wallet screen to match the updated mocks

<img width="320" alt="screen shot 2018-11-19 at 4 24 20 pm" src="https://user-images.githubusercontent.com/14582709/48739166-bc75b100-ec18-11e8-8934-bbe934f96b16.png">
<img width="336" alt="screen shot 2018-11-19 at 4 27 49 pm" src="https://user-images.githubusercontent.com/14582709/48739167-bc75b100-ec18-11e8-9d99-1717acb026b9.png">
