### PR TITLE
#278 Modal Height Bug

### DIFF
--- a/src/styles/shared/modalStyles.js
+++ b/src/styles/shared/modalStyles.js
@@ -46,7 +46,7 @@ const ModalStyles = {
     backgroundColor: containerDarkColor,
     borderTopLeftRadius: 6,
     borderTopRightRadius: 6,
-    height: fullHeight - 325,
+    height: fullHeight - 225,
     marginHorizontal: globalMargin,
     marginTop: globalMargin,
     overflow: 'hidden',


### PR DESCRIPTION
Connected to #278 

- Put in a fix for the modal height bug and checked on multiple devices

iPhone 6:
![img_2742](https://user-images.githubusercontent.com/14582709/48860704-45125f80-ed87-11e8-9e09-34e9e0084bfb.PNG)

Android:
![screenshot_2018-11-21-11-44-35](https://user-images.githubusercontent.com/14582709/48860720-4e9bc780-ed87-11e8-83f7-bec06b031dd7.png)

iPhone X:
<img width="368" alt="screen shot 2018-11-21 at 12 12 16 pm" src="https://user-images.githubusercontent.com/14582709/48860730-55c2d580-ed87-11e8-8d8a-aef2a8060a6c.png">


