### PR TITLE
Changed the endpoint for ticket redemption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # dependencies
 /node_modules
 /.vscode
+/.idea
 
 # misc
 .env.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -2754,9 +2754,9 @@
       "dev": true
     },
     "bn-api-node": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/bn-api-node/-/bn-api-node-0.3.2.tgz",
-      "integrity": "sha512-wsUzppNaJyEx0ICyTzV6fqRxhiC/5cfZ6HCMMet+VnV0vWqiM2yVYLtFEzc+swCFG+oYX9x0ZCE9j26EQGJRDA==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/bn-api-node/-/bn-api-node-0.3.5.tgz",
+      "integrity": "sha512-NqKtWimZe1Lic+spmdNc/fvp+E8lxkhJD+06aDvvyKsEWsGR0imYAtbYcGi36xXtxTacTy+tDDECAd6EuFBYCg==",
       "requires": {
         "axios": "^0.18.0"
       },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "preset": "jest-expo"
   },
   "dependencies": {
-    "bn-api-node": "^0.3.2",
+    "bn-api-node": "^0.3.5",
     "expo": "^27.0.1",
     "lodash": "^4.17.11",
     "luxon": "^1.4.4",

--- a/src/state/eventManagerStateProvider.js
+++ b/src/state/eventManagerStateProvider.js
@@ -58,13 +58,15 @@ class EventManagerContainer extends Container {
   _redeem = async (ticket, _scanner) => {
     let _message;
 
+    const event_id = this.state.eventToScan.id;
     try {
-      const result = await server.tickets.redeem.redeem({
+      const result = await server.events.tickets.redeem({
+        event_id,
         ticket_id: ticket.data.id,
         redeem_key: ticket.data.redeem_key,
       });
-
-      if (result.data.success) {
+      //The attendee details will be in result.data
+      if (result.status === 200) {
         // Redeemed
         this.setState({scanResult: 'success'}, this._resetScanResult)
       } else {
@@ -103,7 +105,7 @@ class EventManagerContainer extends Container {
         // }
       }
     } catch (e) {
-      // alert(e);
+      alert(e);
     }
   }
 }


### PR DESCRIPTION
Changed the endpoint to match the new version of bn-api-node (0.3.5)
A valid response is also no longer in data.success it is status === 200
The server.events.tickets.redeem endpoint also requires `event_id`