### PR TITLE
#85 Nav Overlap Bug - Android

### DIFF
--- a/src/navigators/appNavigator.js
+++ b/src/navigators/appNavigator.js
@@ -63,4 +63,5 @@ export default createBottomTabNavigator(
       },
     },
   },
+  tabBarOptions: {},
 )

--- a/src/styles/shared/navigationStyles.js
+++ b/src/styles/shared/navigationStyles.js
@@ -41,6 +41,7 @@ const NavigationStyles = {
   headerTitle: {
     fontFamily: globalFontSemiBold,
     fontSize: headerFontSize,
+    // paddingLeft: globalPaddingLarge, // Add this padding for Android only
   },
   headerLeftWrapper: {
     flexDirection: 'row',

--- a/src/styles/shared/navigationStyles.js
+++ b/src/styles/shared/navigationStyles.js
@@ -41,7 +41,11 @@ const NavigationStyles = {
   headerTitle: {
     fontFamily: globalFontSemiBold,
     fontSize: headerFontSize,
-    // paddingLeft: globalPaddingLarge, // Add this padding for Android only
+    ...Platform.select({
+      android: {
+        paddingLeft: globalPaddingLarge,
+      },
+    })
   },
   headerLeftWrapper: {
     flexDirection: 'row',


### PR DESCRIPTION
Connected to #85 

- Put in a fix for the nav overlap bug on Android only
- Fixed the missing AppNavigator styles (I think this was removed on accident)

**Please note**:
The only possible fix for this bug was to align the Back button with the Nav Title on the left and give it some padding on Android only. This is a known bug that users have and this is the only decent solution. Everything matches the mocks on iOS but Android will have to be slightly off

Android:
![android](https://user-images.githubusercontent.com/14582709/49036983-afa80e80-f17e-11e8-8440-29f0026f09c8.png)

iOS:
<img width="342" alt="screen shot 2018-11-26 at 1 16 27 pm" src="https://user-images.githubusercontent.com/14582709/49036988-b59def80-f17e-11e8-9c39-2d28a5a97f70.png">
