### PR TITLE
#302 Remove Ticket Wallet Buttons

### DIFF
--- a/src/Tickets/Ticket.js
+++ b/src/Tickets/Ticket.js
@@ -69,6 +69,7 @@ export default class Ticket extends Component {
           />
         </View>
 
+        {false && // TODO: Re-enable when functionality is implemented.
         <View style={ticketWalletStyles.bottomNav}>
           <View style={[ticketWalletStyles.bottomNavLinkContainer, styles.borderRight]}>
             <Icon style={ticketWalletStyles.bottomNavIcon} name="account-balance-wallet" />
@@ -81,6 +82,7 @@ export default class Ticket extends Component {
             </View>
           </TouchableHighlight>
         </View>
+        }
       </View>
     )
   }

--- a/src/Tickets/Ticket.js
+++ b/src/Tickets/Ticket.js
@@ -24,10 +24,12 @@ export default class Ticket extends Component {
     return (
       <View>
         <View style={ticketStyles.ticketContainer}>
-          <Image
-            style={ticketWalletStyles.eventImage}
-            source={ticket.image}
-          />
+          <View style={ticketWalletStyles.eventImageWrapper}>
+            <Image
+              style={ticketWalletStyles.eventImage}
+              source={ticket.image}
+            />
+          </View>
           <View style={ticketStyles.detailsContainer}>
             <View>
               <View style={styles.iconLinkContainer}>

--- a/src/styles/tickets/ticketWalletStyles.js
+++ b/src/styles/tickets/ticketWalletStyles.js
@@ -63,11 +63,16 @@ const TicketWalletStyles = {
   },
 
   // IMAGE STYLES
-  eventImage: {
-    borderTopRightRadius: 6,
-    borderTopLeftRadius: 6,
-    height: 180,
+  eventImageWrapper: {
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 0,
+    borderTopLeftRadius: 10,
+    borderTopRightRadius: 10,
+    overflow: 'hidden',
     position: 'absolute',
+  },
+  eventImage: {
+    height: 180,
     width: fullWidth - 43,
   },
   modalBkgdImage: {
@@ -120,6 +125,8 @@ const TicketWalletStyles = {
   // QR CODE STYLES
   qrCodeContainer: {
     backgroundColor: containerDarkColor,
+    borderBottomRightRadius: 10,
+    borderBottomLeftRadius: 10,
     flexDirection: 'row',
     justifyContent: 'center',
     padding: globalPadding,


### PR DESCRIPTION
Connected to #302 

- Commented out the action buttons on the Ticket Wallet carousel
- Fixed bottom border radius
- Fixed top right border radius on carousel tickets
- Checked on iOS and Android

Assigning to @blazebarsamian to review and approve styles
Assigning to @daybreaker to review how I commented out the section in `/Tickets/Ticket.js`

Simulator:
<img width="375" alt="screen shot 2018-11-28 at 4 21 26 pm" src="https://user-images.githubusercontent.com/14582709/49187699-fe47db00-f32d-11e8-9036-02e691cacce6.png">

iPhone 6s:
![iphone6](https://user-images.githubusercontent.com/14582709/49187714-09027000-f32e-11e8-8d5e-b0ae5b313d35.PNG)

Android:
![screenshot_2018-11-28-16-49-38](https://user-images.githubusercontent.com/14582709/49187730-1a4b7c80-f32e-11e8-8e02-bfa636e15e91.png)


