### PR TITLE
Changing error from console to alert

### DIFF
--- a/src/Events/payments.js
+++ b/src/Events/payments.js
@@ -92,8 +92,7 @@ export default class PaymentTypes extends Component {
     const payment = JSON.parse(data)
 
     if (payment.error) {
-      // @TODO: Change to alert, and modify bn-web to reset state on error
-      console.log('error', payment.error); // eslint-disable-line
+      alert(`There was an error.\n\n${payment.error}`);
     } else {
       this.props.selectPayment(payment)
     }

--- a/src/constants/Server.js
+++ b/src/constants/Server.js
@@ -9,7 +9,6 @@ if ((typeof basicAuthUsername === 'string' && !basicAuthUsername) || (typeof bas
 }
 const authString = basicAuthUsername || basicAuthPassword ? `${basicAuthUsername}:${basicAuthPassword}@` : '';
 
-
 export const BASE_URL = `https://${authString}staging.bigneon.com`;
 
 export const server = new Bigneon.Server({prefix: `${BASE_URL}/api`})// , {}, mocker)


### PR DESCRIPTION
connects #263 

Alerts any errors coming back from bn-web's Stripe form.

----

Note: Corresponding bn-web PR: https://github.com/big-neon/bn-web/pull/494

This will clear the loading state from the card form on error.

The card form will still be frozen on error until that PR is merged and pushed to staging.