### PR TITLE
Check access token for expiration before API calls

### DIFF
--- a/App.js
+++ b/App.js
@@ -36,7 +36,6 @@ export default class App extends Component {
   //   this.props.navigation.navigate('Auth');
   // };
 
-  // eslint-disable-next-line complexity
   render() {
     if (!this.state.isSplashReady) {
       return (

--- a/src/Auth/AuthLoadingScreen.js
+++ b/src/Auth/AuthLoadingScreen.js
@@ -2,12 +2,12 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types'
 import {
   ActivityIndicator,
-  AsyncStorage,
   StatusBar,
   View,
 } from 'react-native';
 import {Subscribe} from 'unstated'
 import {AuthContainer} from '../state/authStateProvider'
+import {retrieveTokens} from '../constants/Server'
 
 class AuthStore extends Component {
   static propTypes = {
@@ -23,8 +23,7 @@ class AuthStore extends Component {
   // Fetch the token from storage then navigate to our appropriate place
   _bootstrapAsync = async () => { // eslint-disable-line complexity,space-before-function-paren
     const {navigation: {navigate}, auth} = this.props
-    const userToken = await AsyncStorage.getItem('userToken');
-    const refreshToken = await AsyncStorage.getItem('refreshToken');
+    const {userToken, refreshToken} = await retrieveTokens()
 
     if (userToken && refreshToken) {
       const {state: {currentUser}} = auth

--- a/src/constants/Server.js
+++ b/src/constants/Server.js
@@ -62,7 +62,7 @@ async function refresher() {
 
   // if expired, refresh
   if (userToken && needsRefresh(userToken)) {
-    refreshWithToken(refreshToken)
+    await refreshWithToken(refreshToken)
   }
 }
 

--- a/src/constants/Server.js
+++ b/src/constants/Server.js
@@ -37,7 +37,7 @@ function parseJwt(token) {
   return JSON.parse(window.atob(base64));
 }
 
-export function needsRefresh(token) {
+function needsRefresh(token) {
   if (!token) {
     return false
   }

--- a/src/constants/Server.js
+++ b/src/constants/Server.js
@@ -38,18 +38,13 @@ function parseJwt(token) {
   return JSON.parse(window.atob(base64));
 }
 
-// If the access token is expired, return true
-function needsToRefresh(user) {
-  return user.exp < Math.floor(Date.now() / 1000)
-}
-
 export async function refreshCheck() {
   /* eslint-disable complexity,camelcase */
   const [userToken, refreshToken] = await AsyncStorage.multiGet(['userToken', 'refreshToken'])
   const user = (userToken && userToken[1]) ? parseJwt(userToken[1]) : false
 
   // if expired, refresh
-  if (user && needsToRefresh(user)) {
+  if (user && user.exp < Math.floor(Date.now() / 1000)) {
     const resp = await server.auth.refresh({refresh_token: refreshToken[1]})
     const {data: {access_token, refresh_token}} = resp
 

--- a/src/constants/Server.js
+++ b/src/constants/Server.js
@@ -58,7 +58,7 @@ export async function refreshWithToken(token) {
 }
 
 async function refresher() {
-  const {userToken, refreshToken} = retrieveTokens()
+  const {userToken, refreshToken} = await retrieveTokens()
 
   // if expired, refresh
   if (userToken && needsRefresh(userToken)) {

--- a/src/constants/Server.js
+++ b/src/constants/Server.js
@@ -69,6 +69,10 @@ function wrapInTokenRefresher(fn) {
 }
 
 function proxyGet(server, prop) {
+  if (prop === 'withoutToken') {
+    return server
+  }
+  
   const value = server[prop]
 
   if (typeof value === 'function') {

--- a/src/constants/Server.js
+++ b/src/constants/Server.js
@@ -12,7 +12,6 @@ const authString = basicAuthUsername || basicAuthPassword ? `${basicAuthUsername
 
 export const BASE_URL = `https://${authString}staging.bigneon.com`;
 
-/* eslint-disable complexity */
 export function apiErrorAlert(error, defaultMsg = 'There was a problem.') {
   console.log(defaultMsg, error); // eslint-disable-line no-console
 
@@ -49,7 +48,7 @@ export function needsRefresh(token) {
 }
 
 export async function refresher() {
-  /* eslint-disable complexity,camelcase */
+  /* eslint-disable camelcase */
   const [userToken, refreshToken] = await AsyncStorage.multiGet(['userToken', 'refreshToken'])
 
   // if expired, refresh

--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -22,7 +22,7 @@ const CONFIG = {
     apiURL: 'https://api.bigneon.com',
     baseURL: 'https://prod-1-mobile-www.bigneon.com',
     stripeFormURL: 'https://prod-1-mobile-www.bigneon.com',
-    timeout: 30000,
+    timeout: 10000,
   },
 }
 

--- a/src/state/authStateProvider.js
+++ b/src/state/authStateProvider.js
@@ -1,6 +1,6 @@
 import {Container} from 'unstated'
 import {AsyncStorage} from 'react-native'
-import {server, bigneonServer, apiErrorAlert, needsRefresh} from '../constants/Server'
+import {server, bigneonServer, apiErrorAlert} from '../constants/Server'
 
 /* eslint-disable camelcase,space-before-function-paren */
 class AuthContainer extends Container {
@@ -52,13 +52,11 @@ class AuthContainer extends Container {
   getCurrentUser = async (navigate, access_token, refresh_token, setToken = true) => { // eslint-disable-line space-before-function-paren
     if (setToken) {
       try {
-        if (needsRefresh(access_token)) {
-          const refreshTokenResp = await server.auth.refresh({refresh_token})
-          const {data} = refreshTokenResp
+        const refreshTokenResp = await server.auth.refresh({refresh_token})
+        const {data} = refreshTokenResp
 
-          access_token = data.access_token
-          refresh_token = data.refresh_token
-        }
+        access_token = data.access_token
+        refresh_token = data.refresh_token
 
         await AsyncStorage.multiSet([['userToken', access_token], ['refreshToken', refresh_token]])
 

--- a/src/state/authStateProvider.js
+++ b/src/state/authStateProvider.js
@@ -49,7 +49,6 @@ class AuthContainer extends Container {
     })
   }
 
-  // eslint-disable-next-line complexity
   getCurrentUser = async (navigate, access_token, refresh_token, setToken = true) => { // eslint-disable-line space-before-function-paren
     if (setToken) {
       try {
@@ -111,7 +110,6 @@ class AuthContainer extends Container {
     }
   }
 
-  /* eslint-disable complexity */
   hasScope = (key) => {
     const {currentUser} = this.state
 

--- a/src/state/authStateProvider.js
+++ b/src/state/authStateProvider.js
@@ -33,6 +33,8 @@ class AuthContainer extends Container {
 
   // Can set tokens after login or signup
   async setTokens(resp, navigate, refresh = false) {
+    console.log("RESP LOGIN:", resp);
+
     const {data: {access_token, refresh_token}} = resp
 
     await AsyncStorage.setItem('userToken', access_token)
@@ -83,7 +85,7 @@ class AuthContainer extends Container {
 
   updateCurrentUser = async (params) => {
     try {
-      await refreshCheck()
+
       const {data} = await server.users.update(params)
 
       await this.setState({currentUser: data})

--- a/src/state/authStateProvider.js
+++ b/src/state/authStateProvider.js
@@ -1,6 +1,6 @@
 import {Container} from 'unstated'
 import {AsyncStorage} from 'react-native'
-import {server, apiErrorAlert} from '../constants/Server'
+import {server, apiErrorAlert, refreshCheck} from '../constants/Server'
 
 /* eslint-disable camelcase,space-before-function-paren */
 class AuthContainer extends Container {
@@ -83,6 +83,7 @@ class AuthContainer extends Container {
 
   updateCurrentUser = async (params) => {
     try {
+      await refreshCheck()
       const {data} = await server.users.update(params)
 
       await this.setState({currentUser: data})
@@ -108,6 +109,7 @@ class AuthContainer extends Container {
     }
   }
 
+  /* eslint-disable complexity */
   hasScope = (key) => {
     const {currentUser} = this.state
 

--- a/src/state/authStateProvider.js
+++ b/src/state/authStateProvider.js
@@ -59,9 +59,7 @@ class AuthContainer extends Container {
         refresh_token = data.refresh_token
 
         await AsyncStorage.multiSet([['userToken', access_token], ['refreshToken', refresh_token]])
-
-        // needs to use direct bigneonServer because proxy server cant set token on itself
-        await bigneonServer.client.setToken(access_token)
+        await server.withoutToken.client.setToken(access_token)
       } catch (error) {
         apiErrorAlert(error, 'There was a problem logging you in.')
 

--- a/src/state/cartStateProvider.js
+++ b/src/state/cartStateProvider.js
@@ -1,5 +1,5 @@
 import {Container} from 'unstated'
-import {server, apiErrorAlert} from '../constants/Server'
+import {server, apiErrorAlert, refreshCheck} from '../constants/Server'
 
 /**
  *  Right now, this only does one ticket type for one event
@@ -57,6 +57,7 @@ class CartContainer extends Container {
     }]
 
     try {
+      await refreshCheck()
       const response = await server.cart.update({items})
       const {data} = response;
 
@@ -70,6 +71,7 @@ class CartContainer extends Container {
 
   refreshCart = async () => {
     try {
+      await refreshCheck()
       const response = await server.cart.read()
       const {data} = response;
 
@@ -98,6 +100,7 @@ class CartContainer extends Container {
 
   placeOrder = async (onSuccess) => {
     try {
+      await refreshCheck()
       const _resp = await server.cart.checkout({
         amount: this.state.total_in_cents, // @TODO: remove this amount, we shouldn't be specifying it on the frontend
         method: {

--- a/src/state/cartStateProvider.js
+++ b/src/state/cartStateProvider.js
@@ -57,7 +57,6 @@ class CartContainer extends Container {
     }]
 
     try {
-      
       const response = await server.cart.update({items})
       const {data} = response;
 
@@ -71,7 +70,6 @@ class CartContainer extends Container {
 
   refreshCart = async () => {
     try {
-      
       const response = await server.cart.read()
       const {data} = response;
 
@@ -100,7 +98,7 @@ class CartContainer extends Container {
 
   placeOrder = async (onSuccess) => {
     try {
-      
+
       const _resp = await server.cart.checkout({
         amount: this.state.total_in_cents, // @TODO: remove this amount, we shouldn't be specifying it on the frontend
         method: {

--- a/src/state/cartStateProvider.js
+++ b/src/state/cartStateProvider.js
@@ -1,5 +1,5 @@
 import {Container} from 'unstated'
-import {server, apiErrorAlert, refreshCheck} from '../constants/Server'
+import {server, apiErrorAlert} from '../constants/Server'
 
 /**
  *  Right now, this only does one ticket type for one event

--- a/src/state/cartStateProvider.js
+++ b/src/state/cartStateProvider.js
@@ -57,7 +57,7 @@ class CartContainer extends Container {
     }]
 
     try {
-      await refreshCheck()
+      
       const response = await server.cart.update({items})
       const {data} = response;
 
@@ -71,7 +71,7 @@ class CartContainer extends Container {
 
   refreshCart = async () => {
     try {
-      await refreshCheck()
+      
       const response = await server.cart.read()
       const {data} = response;
 
@@ -100,7 +100,7 @@ class CartContainer extends Container {
 
   placeOrder = async (onSuccess) => {
     try {
-      await refreshCheck()
+      
       const _resp = await server.cart.checkout({
         amount: this.state.total_in_cents, // @TODO: remove this amount, we shouldn't be specifying it on the frontend
         method: {

--- a/src/state/eventManagerStateProvider.js
+++ b/src/state/eventManagerStateProvider.js
@@ -1,10 +1,6 @@
 import {Container} from 'unstated'
-<<<<<<< HEAD
 import {server, apiErrorAlert} from '../constants/Server'
-=======
-import {server} from '../constants/Server'
 import * as vibe from '../vibe'
->>>>>>> origin/develop
 
 const SCAN_MESSAGE_TIMEOUT = 3000;
 

--- a/src/state/eventManagerStateProvider.js
+++ b/src/state/eventManagerStateProvider.js
@@ -1,5 +1,5 @@
 import {Container} from 'unstated'
-import {server, apiErrorAlert, refreshCheck} from '../constants/Server'
+import {server, apiErrorAlert} from '../constants/Server'
 
 const SCAN_MESSAGE_TIMEOUT = 3000;
 

--- a/src/state/eventManagerStateProvider.js
+++ b/src/state/eventManagerStateProvider.js
@@ -27,7 +27,7 @@ export class EventManagerContainer extends Container {
   // TODO: filter by live vs upcoming?
   getEvents = async () => {
     try {
-      await refreshCheck()
+      
       const {data} = await server.events.index()
 
       this.setState({
@@ -46,7 +46,7 @@ export class EventManagerContainer extends Container {
 
   _transfer = async () => {
     try {
-      await refreshCheck()
+      
       const _result = await server.tickets.transfer.receive(this.state.ticketInfo);
 
       this.setState({scanType: '', statusMessage: 'Successfully Transferred', ticketInfo: {}});
@@ -65,7 +65,7 @@ export class EventManagerContainer extends Container {
     const event_id = this.state.eventToScan.id
 
     try {
-      await refreshCheck()
+      
       await server.events.tickets.redeem({
         event_id,
         ticket_id: ticket.data.id,

--- a/src/state/eventManagerStateProvider.js
+++ b/src/state/eventManagerStateProvider.js
@@ -3,7 +3,7 @@ import {server, apiErrorAlert, refreshCheck} from '../constants/Server'
 
 const SCAN_MESSAGE_TIMEOUT = 3000;
 
-/* eslint-disable camelcase,complexity,space-before-function-paren */
+/* eslint-disable camelcase,space-before-function-paren */
 export class EventManagerContainer extends Container {
   constructor(props = {}) {
     super(props);
@@ -27,7 +27,7 @@ export class EventManagerContainer extends Container {
   // TODO: filter by live vs upcoming?
   getEvents = async () => {
     try {
-      
+
       const {data} = await server.events.index()
 
       this.setState({
@@ -46,7 +46,7 @@ export class EventManagerContainer extends Container {
 
   _transfer = async () => {
     try {
-      
+
       const _result = await server.tickets.transfer.receive(this.state.ticketInfo);
 
       this.setState({scanType: '', statusMessage: 'Successfully Transferred', ticketInfo: {}});
@@ -65,7 +65,7 @@ export class EventManagerContainer extends Container {
     const event_id = this.state.eventToScan.id
 
     try {
-      
+
       await server.events.tickets.redeem({
         event_id,
         ticket_id: ticket.data.id,

--- a/src/state/eventStateProvider.js
+++ b/src/state/eventStateProvider.js
@@ -1,5 +1,5 @@
 import {Container} from 'unstated'
-import {server, BASE_URL, apiErrorAlert, refreshCheck} from '../constants/Server'
+import {server, BASE_URL, apiErrorAlert} from '../constants/Server'
 import {DateTime} from 'luxon'
 
 const LOCATIONS_FETCH_MIN_MINUTES = 15

--- a/src/state/eventStateProvider.js
+++ b/src/state/eventStateProvider.js
@@ -51,7 +51,7 @@ class EventsContainer extends Container {
 
   _fetchLocations = async () => {
     try {
-      await refreshCheck()
+
       const {data: {data: locations}} = await server.regions.index()
 
       await this.setState({locations})
@@ -61,8 +61,7 @@ class EventsContainer extends Container {
   }
 
   getEvents = async (_location = null) => {
-      try {
-      await refreshCheck()
+    try {
       const [{data}, ..._rest] = await Promise.all([server.events.index(), this.fetchLocations()])
 
       data.data.forEach((event) => {
@@ -87,7 +86,7 @@ class EventsContainer extends Container {
 
   getEvent = async (id) => {
     try {
-      await refreshCheck()
+
       const {data} = await server.events.read({id})
 
       if (!data.promo_image_url) {
@@ -109,8 +108,6 @@ class EventsContainer extends Container {
     const {user_is_interested, id} = event
 
     try {
-      const _refresh = await refreshCheck()
-
       if (user_is_interested) {
         // User already interested, so delete it.
         const _response = await server.events.interests.remove({event_id: id})

--- a/src/state/ticketStateProvider.js
+++ b/src/state/ticketStateProvider.js
@@ -1,5 +1,5 @@
 import {Container} from 'unstated'
-import {server, apiErrorAlert, refreshCheck} from '../constants/Server'
+import {server, apiErrorAlert} from '../constants/Server'
 import {DateTime} from 'luxon'
 import {find} from 'lodash'
 

--- a/src/state/ticketStateProvider.js
+++ b/src/state/ticketStateProvider.js
@@ -1,94 +1,7 @@
 import {Container} from 'unstated'
-import {server, apiErrorAlert} from '../constants/Server'
+import {server, apiErrorAlert, refreshCheck} from '../constants/Server'
 import {DateTime} from 'luxon'
 import {find} from 'lodash'
-
-// Hardcoding for now, will probably be replaced by a URL,
-// and <Image source={{uri: ticket.imageUrl}} ... />
-const sampleImages = {
-  image1: require('../../assets/ticket-event.png'),
-  image2: require('../../assets/ticket-event-2.png'),
-}
-const _sampleTickets = {
-  upcoming: [
-    {
-      quantity: 3,
-      name: 'Explosions In The Sky',
-      venue: 'Fox Theater',
-      location: 'Oakland, CA',
-      date: 'Tue, July 21st',
-      starts: '7:30pm',
-      ends: '12:30am',
-      image: sampleImages.image1,
-      qrCode: '',
-      id: 1,
-    },
-    {
-      quantity: 3,
-      name: 'Tycho',
-      venue: 'Fox Theater',
-      location: 'Oakland, CA',
-      date: 'Tue, July 21st',
-      starts: '7:30pm',
-      ends: '12:30am',
-      image: sampleImages.image2,
-      qrCode: '',
-      id: 2,
-    },
-  ],
-  past: [
-    {
-      quantity: 3,
-      name: 'Tycho',
-      venue: 'Fox Theater',
-      location: 'Oakland, CA',
-      date: 'Tue, January 21st',
-      starts: '7:30pm',
-      ends: '12:30am',
-      image: sampleImages.image2,
-      qrCode: '',
-      id: 3,
-    },
-    {
-      quantity: 3,
-      name: 'Explosions In The Sky',
-      venue: 'Fox Theater',
-      location: 'Oakland, CA',
-      date: 'Tue, January 21st',
-      starts: '7:30pm',
-      ends: '12:30am',
-      image: sampleImages.image1,
-      qrCode: '',
-      id: 4,
-    },
-  ],
-  transfer: [
-    {
-      quantity: 1,
-      name: 'Tycho',
-      venue: 'Fox Theater',
-      location: 'Oakland, CA',
-      date: 'Tue, January 21st',
-      starts: '7:30pm',
-      ends: '12:30am',
-      image: sampleImages.image2,
-      qrCode: '',
-      id: 5,
-    },
-    {
-      quantity: 1,
-      name: 'Explosions In The Sky',
-      venue: 'Fox Theater',
-      location: 'Oakland, CA',
-      date: 'Tue, January 21st',
-      starts: '7:30pm',
-      ends: '12:30am',
-      image: sampleImages.image1,
-      qrCode: '',
-      id: 6,
-    },
-  ],
-}
 
 /* eslint-disable camelcase,space-before-function-paren */
 
@@ -107,6 +20,7 @@ class TicketsContainer extends Container {
   // Grabbing tickets from orders right now - not preserving any order-level details
   userTickets = async () => {
     try {
+      await refreshCheck()
       const response = await server.tickets.index()
 
       const {data, _paging} = response.data; // @TODO: pagination
@@ -150,6 +64,7 @@ class TicketsContainer extends Container {
 
   redeemTicketInfo = async (ticket_id) => { // eslint-disable-line complexity
     try {
+      await refreshCheck()
       const response = await server.tickets.redeem.read({ticket_id})
 
       return response.data;

--- a/src/state/ticketStateProvider.js
+++ b/src/state/ticketStateProvider.js
@@ -20,7 +20,7 @@ class TicketsContainer extends Container {
   // Grabbing tickets from orders right now - not preserving any order-level details
   userTickets = async () => {
     try {
-      await refreshCheck()
+      
       const response = await server.tickets.index()
 
       const {data, _paging} = response.data; // @TODO: pagination
@@ -64,7 +64,7 @@ class TicketsContainer extends Container {
 
   redeemTicketInfo = async (ticket_id) => { // eslint-disable-line complexity
     try {
-      await refreshCheck()
+      
       const response = await server.tickets.redeem.read({ticket_id})
 
       return response.data;

--- a/src/state/ticketStateProvider.js
+++ b/src/state/ticketStateProvider.js
@@ -20,7 +20,6 @@ class TicketsContainer extends Container {
   // Grabbing tickets from orders right now - not preserving any order-level details
   userTickets = async () => {
     try {
-      
       const response = await server.tickets.index()
 
       const {data, _paging} = response.data; // @TODO: pagination
@@ -64,7 +63,7 @@ class TicketsContainer extends Container {
 
   redeemTicketInfo = async (ticket_id) => { // eslint-disable-line complexity
     try {
-      
+
       const response = await server.tickets.redeem.read({ticket_id})
 
       return response.data;


### PR DESCRIPTION
connects #342 

Adds a refreshCheck promise that can be called before an API call, that will check if the access token is expired, and use the refresh token to renew it if it is.

Also wrapped more api calls in try/catch to prevent freezing the app on errors

Also refactored a bunch of server code to reduce duplicate code, and move other code in to more reasonable locations.