### PR TITLE
#441 Bottom Nav Text Color Fix

### DIFF
--- a/src/navigators/appNavigator.js
+++ b/src/navigators/appNavigator.js
@@ -8,24 +8,6 @@ import AccountsStack from './accountStack'
 
 const navigationStyles = NavigationStyles.createStyles()
 
-const tabBarOptions = {
-  tabBarOptions: {
-    activeTintColor: '#FF20B1',
-    inactiveTintColor: 'black',
-    labelStyle: {
-      fontFamily: 'tt_commons_regular',
-      fontSize: 13,
-    },
-    style: {
-      backgroundColor: 'white',
-      borderWidth: 0,
-      borderTopColor: '#DCDCDC',
-      height: 50,
-      paddingVertical: 4,
-    },
-  },
-}
-
 /* eslint-disable react/display-name, react/prop-types */
 export default createBottomTabNavigator(
   {
@@ -64,6 +46,20 @@ export default createBottomTabNavigator(
     },
   },
   {
-    tabBarOptions,
+    tabBarOptions: {
+      activeTintColor: '#FF20B1',
+      inactiveTintColor: 'black',
+      labelStyle: {
+        fontFamily: 'tt_commons_regular',
+        fontSize: 13,
+      },
+      style: {
+        backgroundColor: 'white',
+        borderWidth: 0,
+        borderTopColor: '#DCDCDC',
+        height: 50,
+        paddingVertical: 4,
+      },
+    },
   },
 )

--- a/src/navigators/appNavigator.js
+++ b/src/navigators/appNavigator.js
@@ -8,23 +8,23 @@ import AccountsStack from './accountStack'
 
 const navigationStyles = NavigationStyles.createStyles()
 
-// const tabBarOptions = {
-//   tabBarOptions: {
-//     activeTintColor: '#FF20B1',
-//     inactiveTintColor: 'black',
-//     labelStyle: {
-//       fontFamily: 'tt_commons_regular',
-//       fontSize: 13,
-//     },
-//     style: {
-//       backgroundColor: 'white',
-//       borderWidth: 0,
-//       borderTopColor: '#DCDCDC',
-//       height: 50,
-//       paddingVertical: 4,
-//     },
-//   },
-// }
+const tabBarOptions = {
+  tabBarOptions: {
+    activeTintColor: '#FF20B1',
+    inactiveTintColor: 'black',
+    labelStyle: {
+      fontFamily: 'tt_commons_regular',
+      fontSize: 13,
+    },
+    style: {
+      backgroundColor: 'white',
+      borderWidth: 0,
+      borderTopColor: '#DCDCDC',
+      height: 50,
+      paddingVertical: 4,
+    },
+  },
+}
 
 /* eslint-disable react/display-name, react/prop-types */
 export default createBottomTabNavigator(
@@ -64,6 +64,6 @@ export default createBottomTabNavigator(
     },
   },
   {
-    tabBarOptions: {},
+    tabBarOptions,
   },
 )


### PR DESCRIPTION
Connect #441 

- Fixed the styles in `appNavigator.js` by moving to the bottom while keeping them within the brackets

Assigning to @daybreaker for review. (this was the only solution I could find that worked, let me know if this will throw errors but I didn't see any)

<img width="327" alt="screen shot 2019-01-16 at 11 23 03 am" src="https://user-images.githubusercontent.com/14582709/51266830-df56e400-1981-11e9-9b1f-d166e27ae3e3.png">
