### PR TITLE
Fix bug with alert & modal on card decline

### DIFF
--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -123,6 +123,7 @@ export default class EventShow extends Component {
       currentScreen: 'details',
       showLoadingModal: false,
       showSuccessModal: false,
+      success: true,
     }
     this.loadEvent()
   }
@@ -364,6 +365,8 @@ export default class EventShow extends Component {
 
   purchaseTicket = async () => {
     const {screenProps: {cart, setPurchasedTicket}, navigation: {navigate}} = this.props
+    const onSuccess = () => this.setState({success: true})
+    const onError = () => this.setState({showLoadingModal: false, success: false})
 
     if (cart.totalCents && !cart.payment) {
       alert('Please enter your payment details');
@@ -372,8 +375,14 @@ export default class EventShow extends Component {
 
     this.setState({showLoadingModal: true})
     try {
-      await cart.placeOrder()
-      setPurchasedTicket(cart.id)
+      await cart.placeOrder(onSuccess, onError)
+
+      if (!this.state.success) {
+        return false
+      } else {
+        setPurchasedTicket(cart.id)
+      }
+
 
       await this.setState({
         showLoadingModal: false,

--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -123,7 +123,7 @@ export default class EventShow extends Component {
       currentScreen: 'details',
       showLoadingModal: false,
       showSuccessModal: false,
-      success: true,
+      success: null,
     }
     this.loadEvent()
   }

--- a/src/state/cartStateProvider.js
+++ b/src/state/cartStateProvider.js
@@ -205,7 +205,7 @@ class CartContainer extends Container {
     return !this.isChangingQuantity && !this.totalCents || this.payment
   }
 
-  async placeOrder() {
+  async placeOrder(onSuccess, onError) {
     const {totalCents: amount} = this
     const method = amount ? {
       type: 'Card',
@@ -219,8 +219,12 @@ class CartContainer extends Container {
 
     try {
       await server.cart.checkout({amount, method})
+      onSuccess()
     } catch(error) {
-      apiErrorAlert(error)
+      onError()
+      setTimeout(() => {
+        apiErrorAlert(error)
+      }, 600);
     }
   }
 }


### PR DESCRIPTION
connects #534 

adds a timeout to the alert, since there is a React native bug around displaying an alert immediately after closing a `Modal` component. 

https://github.com/facebook/react-native/issues/10471