### PR TITLE
Improving SignUp UI

### DIFF
--- a/src/Auth/SignUp.js
+++ b/src/Auth/SignUp.js
@@ -56,7 +56,7 @@ export default class SignUp extends Component {
   render() {
     return (
       <KeyboardAvoidingView style={loginStyles.container} behavior="padding" enabled>
-        <ScrollView showsVerticalScrollIndicator={false}>
+        <ScrollView showsVerticalScrollIndicator={false} keyboardShouldPersistTaps={'handled'}>
           <View>
             <Text style={loginStyles.smallText}>
               Secure your experiences

--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
-import {ScrollView, Text, View, Image, Modal, ActivityIndicator, TouchableHighlight, KeyboardAvoidingView} from 'react-native'
+import {ScrollView, Text, View, Image, TouchableHighlight, KeyboardAvoidingView} from 'react-native'
 import {WebBrowser} from 'expo';
 import {NavigationActions, StackActions, NavigationEvents} from 'react-navigation'
 import Icon from 'react-native-vector-icons/MaterialIcons'
@@ -10,15 +10,15 @@ import Details from './details'
 import GetTickets from './tickets'
 import PaymentTypes from './payments'
 import Checkout from './checkout'
-import ModalStyles from '../styles/shared/modalStyles'
 import {toDollars} from '../constants/money'
+import {LoadingScreen, SuccessScreen} from '../constants/modals'
 import {server, apiErrorAlert} from '../constants/Server'
 import {min, max, isEmpty, uniq} from 'lodash'
 import {optimizeCloudinaryImage} from '../cloudinary'
 
 const styles = SharedStyles.createStyles()
 const eventDetailsStyles = EventDetailsStyles.createStyles()
-const modalStyles = ModalStyles.createStyles()
+
 
 /* eslint-disable camelcase, space-before-function-paren */
 function priceRangeString(ticket_types) {
@@ -36,56 +36,6 @@ function priceRangeString(ticket_types) {
   }
 
   return uniq([min(prices), max(prices)]).map((cents) => `$${toDollars(cents, 0)}`).join(' - ')
-}
-
-
-const LoadingScreen = ({toggleModal, modalVisible}) => (
-  <Modal
-    onRequestClose={() => {
-      toggleModal(!modalVisible)
-    }}
-    visible={modalVisible}
-    transparent
-  >
-    <View style={modalStyles.modalContainer}>
-      <View style={styles.flexRowCenter}>
-        <View style={modalStyles.activityIndicator}>
-          <ActivityIndicator size="large" color="#FF20B1" />
-        </View>
-      </View>
-    </View>
-  </Modal>
-)
-
-LoadingScreen.propTypes = {
-  toggleModal: PropTypes.func.isRequired,
-  modalVisible: PropTypes.bool.isRequired,
-}
-
-const SuccessScreen = ({toggleModal, modalVisible}) => (
-  <Modal
-    onRequestClose={() => {
-      toggleModal(!modalVisible)
-    }}
-    visible={modalVisible}
-    transparent
-  >
-    <View style={modalStyles.modalContainer}>
-      <View style={styles.flexRowCenter}>
-        <View style={modalStyles.activityIndicator}>
-          <Image
-            style={modalStyles.emojiActivityIndicator}
-            source={require('../../assets/emoji-loader.png')}
-          />
-        </View>
-      </View>
-    </View>
-  </Modal>
-)
-
-SuccessScreen.propTypes = {
-  toggleModal: PropTypes.func.isRequired,
-  modalVisible: PropTypes.bool.isRequired,
 }
 
 function CheckoutButton({onCheckout, disabled, busy}) {
@@ -218,7 +168,7 @@ export default class EventShow extends Component {
       const {data: {ticket_type}} = response
 
       if (!this.store.ticketTypeIds.includes(ticket_type.id)) {
-        alert ('This Promo Code is not valid for this event')
+        alert('This Promo Code is not valid for this event')
         return
       }
 
@@ -464,7 +414,7 @@ export default class EventShow extends Component {
           source={{uri: optimizeCloudinaryImage(event.promo_image_url)}}
         />
         <KeyboardAvoidingView behavior="padding" enabled>
-          <ScrollView ref={c => (this.scrollView = c)} keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false}>
+          <ScrollView ref={ref => (this.scrollView = ref)} keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false}>
             {this.showScreen}
           </ScrollView>
         </KeyboardAvoidingView>

--- a/src/constants/modals.js
+++ b/src/constants/modals.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {View, Modal, ActivityIndicator, Image} from 'react-native'
+import SharedStyles from '../styles/shared/sharedStyles'
+import ModalStyles from '../styles/shared/modalStyles'
+
+const styles = SharedStyles.createStyles()
+const modalStyles = ModalStyles.createStyles()
+
+export const LoadingScreen = ({toggleModal, modalVisible}) => (
+  <Modal
+    onRequestClose={() => {
+      toggleModal(!modalVisible)
+    }}
+    visible={modalVisible}
+    transparent
+  >
+    <View style={modalStyles.modalContainer}>
+      <View style={styles.flexRowCenter}>
+        <View style={modalStyles.activityIndicator}>
+          <ActivityIndicator size="large" color="#FF20B1" />
+        </View>
+      </View>
+    </View>
+  </Modal>
+)
+
+LoadingScreen.propTypes = {
+  toggleModal: PropTypes.func.isRequired,
+  modalVisible: PropTypes.bool.isRequired,
+}
+
+
+export const SuccessScreen = ({toggleModal, modalVisible}) => (
+  <Modal
+    onRequestClose={() => {
+      toggleModal(!modalVisible)
+    }}
+    visible={modalVisible}
+    transparent
+  >
+    <View style={modalStyles.modalContainer}>
+      <View style={styles.flexRowCenter}>
+        <View style={modalStyles.activityIndicator}>
+          <Image
+            style={modalStyles.emojiActivityIndicator}
+            source={require('../../assets/emoji-loader.png')}
+          />
+        </View>
+      </View>
+    </View>
+  </Modal>
+)
+
+SuccessScreen.propTypes = {
+  toggleModal: PropTypes.func.isRequired,
+  modalVisible: PropTypes.bool.isRequired,
+}

--- a/src/state/authStateProvider.js
+++ b/src/state/authStateProvider.js
@@ -68,7 +68,7 @@ class AuthContainer extends Container {
     }
   }
 
-  updateCurrentUser = async (params) => {
+  updateCurrentUser = async (params, onError = () => {}) => {
     try {
 
       const {data} = await server.users.update(params)
@@ -76,7 +76,11 @@ class AuthContainer extends Container {
       await this.setState({currentUser: data})
       return data
     } catch (error) {
-      apiErrorAlert(error, 'There was an error updating your profile.')
+      onError()
+      setTimeout(() => {
+        apiErrorAlert(error, 'There was an error updating your profile.')
+      }, 600)
+      return false
     }
   }
 


### PR DESCRIPTION
connects #544 

These weren't really iphone X specific.

- Added `keyboardShouldPersistTaps={'handled'}` to the Buttons inside `ScrollView` for SignUp and SignUpNext to allow the button to be pressed while the keyboard is visible.

- Added a modal after pressing `That’s Me` Button on SignUpNext. (Since there was no visual notification the app was doing anything when the user pressed the button, it looked like the button wasnt working if loading the profile photo was taking a long time.)

Tested with a 3MB photo. No issues.

- Added setTimeout to updateProfile error to prevent blocking UI bug when closing a modal and displaying an alert on iOS.