### PR TITLE
Adding config options for ios and android

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,11 +7,20 @@
     "slug": "big-neon-mobile",
     "orientation": "portrait",
     "ios": {
-      "bundleIdentifier": "com.bigneon.mobile"
+      "bundleIdentifier": "com.bigneon.mobile",
+      "config": {
+        "usesNonExemptEncryption": false
+      }
     },
     "android": {
       "package": "com.bigneon.mobile",
-      "versionCode": 27
+      "versionCode": 27,
+      "permissions": [
+        "CAMERA",
+        "CAMERA_ROLL",
+        "NOTIFICATIONS",
+        "LOCATION"
+      ]
     }
   }
 }


### PR DESCRIPTION
connects #477 

- added a `usesNonExemptEncryption` value in ios config to prevent Missing Compliance warnings. This should, in theory, allow deploys to go straight to Test Flight with no manual intervention.

- added a `permissions` array in Android to remove automatic inclusion of SMS_MESSAGE permissions which the Google Play Store no longer allows. (I've seen some things in stack overflow that this might not solve the issue right away and might require extra actions in the Google Platy store to clear out caches or something)