### PR TITLE
handle connectivity errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1577,7 +1577,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "requires": {
         "ansi-wrap": "^0.1.0"
@@ -2001,7 +2001,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -2165,7 +2165,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -2380,7 +2380,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
-      "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
@@ -2410,7 +2410,7 @@
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
       "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
     },
     "babel-plugin-syntax-flow": {
@@ -2420,12 +2420,12 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -4778,7 +4778,7 @@
         },
         "inquirer": {
           "version": "5.2.0",
-          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
           "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
           "dev": true,
           "requires": {
@@ -6669,7 +6669,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
         "builtin-modules": "^1.0.0"
@@ -7371,7 +7371,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },
@@ -8009,7 +8009,7 @@
     },
     "kind-of": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
       "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
     },
     "klaw": {
@@ -8076,7 +8076,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -8453,7 +8453,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -8522,12 +8522,12 @@
         },
         "mime-db": {
           "version": "1.23.0",
-          "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
           "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
         },
         "mime-types": {
           "version": "2.1.11",
-          "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
           "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
           "requires": {
             "mime-db": "~1.23.0"
@@ -9237,7 +9237,7 @@
     },
     "npmlog": {
       "version": "2.0.4",
-      "resolved": "http://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
       "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
       "requires": {
         "ansi": "~0.3.1",
@@ -9415,7 +9415,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         },
         "wordwrap": {
@@ -9458,7 +9458,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
@@ -9773,7 +9773,7 @@
     },
     "pegjs": {
       "version": "0.10.0",
-      "resolved": "http://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
       "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
     },
     "performance-now": {
@@ -10327,7 +10327,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -10352,7 +10352,7 @@
         },
         "pretty-format": {
           "version": "4.3.1",
-          "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
           "integrity": "sha1-UwvlxCs8BbNkFKeipDN6qArNDo0="
         },
         "regenerator-runtime": {
@@ -10859,7 +10859,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
@@ -11106,7 +11106,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -11491,7 +11491,7 @@
     },
     "serialize-error": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serve-static": {
@@ -12127,7 +12127,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
@@ -12349,7 +12349,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
         }
       }
@@ -12379,7 +12379,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -13130,7 +13130,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/src/Accounts/eventScanner.js
+++ b/src/Accounts/eventScanner.js
@@ -40,6 +40,7 @@ const SCAN_ALERT_CONFIG = {
 }
 
 // props for the StatusMessage component, based on the presence and type of error
+/* eslint-disable-next-line complexity */
 function getStatusMessageConfig(error) {
   if (!error) {
     return SCAN_ALERT_CONFIG.success

--- a/src/Accounts/guest-list-checkin.js
+++ b/src/Accounts/guest-list-checkin.js
@@ -145,8 +145,10 @@ function checkInErrorText(guest) {
 }
 
 class GuestList extends Component {
+  // Calm down, eslint. Quit punishing us for handling errors. Geez.
+  /* eslint-disable-next-line complexity */
   onRowOpen = async (rowKey, rowMap, toValue) => {
-    const guest = this.props.guests.find(item => item.id === rowKey)
+    const guest = this.props.guests.find((item) => item.id === rowKey)
 
     if (canCheckOut(guest) && toValue === SCREEN_WIDTH) {
       try {
@@ -156,8 +158,7 @@ class GuestList extends Component {
       }
     }
 
-    const row = rowMap[rowKey]
-    row.closeRow()
+    rowMap[rowKey].closeRow()
   }
 
   render() {
@@ -239,11 +240,11 @@ export default class ManualCheckin extends Component {
     this.searchGuestList()
   }
 
-  searchGuestList = query => {
+  searchGuestList = (query) => {
     this.props.searchGuestList(query)
   }
 
-  selectGuest = selectedGuest => {
+  selectGuest = (selectedGuest) => {
     this.setState({selectedGuest})
   }
 
@@ -251,7 +252,7 @@ export default class ManualCheckin extends Component {
     this.selectGuest(null)
   }
 
-  checkInGuest = async guest => {
+  checkInGuest = async (guest) => {
     const {event_id, id: ticket_id, redeem_key} = guest
 
     try {

--- a/src/constants/Server.js
+++ b/src/constants/Server.js
@@ -27,7 +27,12 @@ function buildErrorMessage({error, fields}) {
   return msg
 }
 
+/* eslint-disable-next-line complexity */
 export function apiErrorAlert(error, msg = DEFAULT_ERROR_MSG) {
+  if (error.message === 'Network Error') {
+    return alert('Network Error: Your device may have lost connectivity.')
+  }
+
   const {response} = error
 
   if (!response) {
@@ -36,7 +41,7 @@ export function apiErrorAlert(error, msg = DEFAULT_ERROR_MSG) {
 
   const {data} = response
 
- return alert(data && data.error && buildErrorMessage(data) || msg)
+  return alert(data && data.error && buildErrorMessage(data) || msg)
 }
 
 export async function retrieveTokens() {

--- a/src/state/eventManagerStateProvider.js
+++ b/src/state/eventManagerStateProvider.js
@@ -39,16 +39,24 @@ export class EventManagerContainer extends Container {
     this.setState({eventToScan: event, guests: []});
   }
 
+  /* eslint-disable-next-line complexity */
   searchGuestList = async (guestListQuery = '') => {
     await this.setState({isFetchingGuests: true, guestListQuery})
 
     const {id} = this.state.eventToScan
-    const {data: {data: guests, paging: _paging}} = await server.events.guests.index({event_id: id, query: guestListQuery})
+    let guests = null
 
-    // Still fetching the same thing? (or subsequently fetched something else?)
-    if (this.state.eventToScan.id === id && this.state.guestListQuery === guestListQuery) {
-      await this.setState({guests, isFetchingGuests: false})
+    try {
+      guests = (await server.events.guests.index({event_id: id, query: guestListQuery})).data.data
+    } catch (error) {
+      apiErrorAlert(error)
     }
+
+    if (guests) {
+      await this.setState({guests})
+    }
+    
+    await this.setState({isFetchingGuests: false})
   }
 
   // this just unpacks the barcode scanner result, nothing else


### PR DESCRIPTION
connect #583 

There are a lot of just drive-by lint fixes in here because I got sick of staring at a wall of red. Note that while I do not typically condone the use of `eslint-disable-next-line complexity`, but in the cases I applied it, it felt like `eslint` was complaining about either logic that was necessarily complex or, more often, counting error handling against us! Annoying.

The meat of the change is this:

* Change `apiErrorAlert` so that it swallows connectivity errors and alerts on them.
* Use `apiErrorAlert` in the guest list search.