### PR TITLE
#588 - Android Galaxy S6 - Guest List text overlapping

### DIFF
--- a/src/Accounts/routes.js
+++ b/src/Accounts/routes.js
@@ -90,7 +90,7 @@ const ROUTES = {
   },
   GuestList: {
     screen: GuestList,
-    navigationOptions: navOptions({title: 'Guest List', back: {route: 'EventScanner', text: 'Scan Tickets'}})
+    navigationOptions: navOptions({back: {route: 'EventScanner', text: 'Scan Tickets'}})
   }
 }
 

--- a/src/styles/shared/navigationStyles.js
+++ b/src/styles/shared/navigationStyles.js
@@ -14,6 +14,7 @@ import {
   globalPaddingTiny,
   globalPaddingSmall,
   globalPaddingLarge,
+  globalPaddingLarger,
 } from './sharedStyles'
 import {StyleSheet, Dimensions, Platform} from 'react-native'
 const fullHeight = Dimensions.get('window').height
@@ -41,7 +42,7 @@ const NavigationStyles = {
     fontSize: globalFontSizeSmall,
     ...Platform.select({
       android: {
-        paddingLeft: globalPaddingLarge,
+        paddingLeft: globalPaddingLarger,
       },
     })
   },


### PR DESCRIPTION
Connected to #588 

- I removed the Header on the TopBar since the header is duplicated on the screen (there are two headers that say "Guest List")
- I found this to be the best solution because this is an ongoing Android bug that I've dug a lot into in the past and haven't been able to find a real workaround
- Checked on an Android s5 because I don't have access to a 6s

![Screenshot_2019-03-08-15-44-53](https://user-images.githubusercontent.com/14582709/54055772-a7b32e00-41b3-11e9-8dd8-f36ae0634dae.png)

