### PR TITLE
606 loading bug

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -255,7 +255,7 @@
     "react/no-unused-prop-types": 1,
     "react/prefer-es6-class": 1,
     "react/prefer-stateless-function": 0,
-    "react/prop-types": 2,
+    "react/prop-types": 0,
     "react/react-in-jsx-scope": 2,
     "react/require-render-return": 2,
     "react/self-closing-comp": 1,

--- a/src/Accounts/guest-list-checkin.js
+++ b/src/Accounts/guest-list-checkin.js
@@ -35,14 +35,6 @@ function shouldAllowCheckIn({status, redeem_key}) {
   return status === 'Purchased' && redeem_key
 }
 
-function BusyState() {
-  return (
-    <View style={ticketStyles.emptyStateContainer}>
-      <Text style={ticketStyles.emptyStateText}>Hang on a sec...</Text>
-    </View>
-  )
-}
-
 function guestStatusBadgeStyle(status) {
   switch (status) {
     case 'Purchased':
@@ -267,9 +259,15 @@ export default class ManualCheckin extends Component {
     }
   }
 
+  get shouldShowLoadingScreen() {
+    const {isFetchingGuests, guests, guestListQuery} = this.props
+
+    return isFetchingGuests && guests.length === 0 && guestListQuery.length === 0
+  }
+
   render() {
     const {selectedGuest} = this.state
-    const {isFetchingGuests, guests, guestListQuery} = this.props
+    const {guests, guestListQuery} = this.props
 
     if (selectedGuest !== null) {
       return (
@@ -303,11 +301,7 @@ export default class ManualCheckin extends Component {
               </View>
             </View>
 
-            {isFetchingGuests && <BusyState />}
-
-            <LoadingScreen
-              toggleModal={this.toggleLoadingModal}
-            />
+            <LoadingScreen visible={this.shouldShowLoadingScreen} />
 
             <GuestList
               style={{flex: 1}}

--- a/src/Accounts/guest-list-checkin.js
+++ b/src/Accounts/guest-list-checkin.js
@@ -22,6 +22,7 @@ import emptyState from '../../assets/icon-empty-state.png'
 import {server, apiErrorAlert} from '../constants/Server'
 import {SwipeListView, SwipeRow} from 'react-native-swipe-list-view'
 import {KeyboardDismisser} from '../ui'
+import {LoadingScreen} from '../constants/modals'
 
 const styles = SharedStyles.createStyles()
 const doormanStyles = DoormanStyles.createStyles()
@@ -303,7 +304,11 @@ export default class ManualCheckin extends Component {
             </View>
 
             {isFetchingGuests && <BusyState />}
-            
+
+            <LoadingScreen
+              toggleModal={this.toggleLoadingModal}
+            />
+
             <GuestList
               style={{flex: 1}}
               guests={guests}

--- a/src/Accounts/guest-list-screen.js
+++ b/src/Accounts/guest-list-screen.js
@@ -8,7 +8,7 @@ export default class GuestListScreen extends Component {
 
     return (
       <View>
-      <GuestList {...managerState} searchGuestList={searchGuestList} />
+        <GuestList {...managerState} searchGuestList={searchGuestList} />
       </View>
     )
   }

--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -157,14 +157,6 @@ export default class EventShow extends Component {
     this.changeScreen('checkout')
   }
 
-  toggleLoadingModal = ({showLoadingModal}) => {
-    this.setState({showLoadingModal})
-  }
-
-  toggleSuccessModal = ({showSuccessModal}) => {
-    this.setState({showSuccessModal})
-  }
-
   get ticketRange() {
     const str = priceRangeString(this.state.event.ticket_types)
 
@@ -479,14 +471,8 @@ export default class EventShow extends Component {
           onWillFocus={() => this.loadEvent()}
           onDidBlur={() => this.clearEvent()}
         />
-        <LoadingScreen
-          toggleModal={this.toggleLoadingModal}
-          modalVisible={showLoadingModal}
-        />
-        <SuccessScreen
-          toggleModal={this.toggleSuccessModal}
-          modalVisible={showSuccessModal}
-        />
+        <LoadingScreen visible={showLoadingModal} />
+        <SuccessScreen visible={showSuccessModal} />
         <Image
           style={eventDetailsStyles.videoBkgd}
           source={{uri: optimizeCloudinaryImage(event.promo_image_url)}}

--- a/src/constants/modals.js
+++ b/src/constants/modals.js
@@ -1,58 +1,75 @@
 import React from 'react'
-import PropTypes from 'prop-types'
-import {View, Modal, ActivityIndicator, Image} from 'react-native'
+import {View, Modal as NativeModal, ActivityIndicator, Image} from 'react-native'
 import SharedStyles from '../styles/shared/sharedStyles'
 import ModalStyles from '../styles/shared/modalStyles'
 
 const styles = SharedStyles.createStyles()
 const modalStyles = ModalStyles.createStyles()
 
-export const LoadingScreen = ({toggleModal, modalVisible}) => (
-  <Modal
-    onRequestClose={() => {
-      toggleModal(!modalVisible)
-    }}
-    visible={modalVisible}
-    transparent
-  >
-    <View style={modalStyles.modalContainer}>
-      <View style={styles.flexRowCenter}>
-        <View style={modalStyles.activityIndicator}>
-          <ActivityIndicator size="large" color="#FF20B1" />
-        </View>
-      </View>
+function ModalContainer({children, style, ...props}) {
+  return (
+    <View style={[modalStyles.modalContainer, style]} {...props}>
+      {children}
     </View>
-  </Modal>
-)
-
-LoadingScreen.propTypes = {
-  toggleModal: PropTypes.func.isRequired,
-  modalVisible: PropTypes.bool.isRequired,
+  )
 }
 
-
-export const SuccessScreen = ({toggleModal, modalVisible}) => (
-  <Modal
-    onRequestClose={() => {
-      toggleModal(!modalVisible)
-    }}
-    visible={modalVisible}
-    transparent
-  >
-    <View style={modalStyles.modalContainer}>
-      <View style={styles.flexRowCenter}>
-        <View style={modalStyles.activityIndicator}>
-          <Image
-            style={modalStyles.emojiActivityIndicator}
-            source={require('../../assets/emoji-loader.png')}
-          />
-        </View>
-      </View>
+function ModalActivityIndicator({children, style, ...props}) {
+  return (
+    <View style={[modalStyles.activityIndicator, style]} {...props}>
+      {children}
     </View>
-  </Modal>
-)
+  )
+}
 
-SuccessScreen.propTypes = {
-  toggleModal: PropTypes.func.isRequired,
-  modalVisible: PropTypes.bool.isRequired,
+function FlexRowCenter({children, style, ...props}) {
+  return (
+    <View style={[styles.flexRowCenter, style]} {...props}>
+      {children}
+    </View>
+  )
+}
+
+function ActivityModal({children, ...props}) {
+  return (
+    <NativeModal transparent {...props}>
+      <ModalContainer>
+        <FlexRowCenter>
+          <ModalActivityIndicator>
+            {children}
+          </ModalActivityIndicator>
+        </FlexRowCenter>
+      </ModalContainer>
+    </NativeModal>
+  )
+}
+
+function SpinnerActivity(props) {
+  return <ActivityIndicator size="large" color="#FF20B1" {...props} />
+}
+
+function EmojiActivity(props) {
+  return (
+    <Image
+      style={modalStyles.emojiActivityIndicator}
+      source={require('../../assets/emoji-loader.png')}
+      {...props}
+    />
+  )
+}
+
+export function LoadingScreen({children: _, ...props}) {
+  return (
+    <ActivityModal {...props}>
+      <SpinnerActivity />
+    </ActivityModal>
+  )
+}
+
+export function SuccessScreen({children: _, ...props}) {
+  return (
+    <ActivityModal {...props}>
+      <EmojiActivity />
+    </ActivityModal>
+  )
 }


### PR DESCRIPTION
connect #606

* Change modals to make sense (usage of `onRequestClose` was all wrong)
* Refactor modals into reusable building blocks
* Add loading indicator modal
* Wire up loading indicator modal to guest list search, only when all of the following are true:
  * Guest list is being fetched
  * Already-fetched guest list is empty
  * Quest list query string is empty

We should circle back on this at some point. The problem with showing the modal _every_ time we have network activity here is that it searches as you type. So if I were to remove the restrictions for when to show the indicator, you'd have to wait for the modal after every keypress.

Longer-term, I think we should put a little spinner inside the search box on its right side.