### PR TITLE
change ticket description

### DIFF
--- a/src/Events/event_ticket.js
+++ b/src/Events/event_ticket.js
@@ -34,13 +34,13 @@ export class Ticket extends Component {
   }
 
   get subHeaderContent() {
-    const {status, ticket_pricing} = this.props.ticket
+    const {description, status, ticket_pricing} = this.props.ticket
 
     switch (status) {
     case 'SoldOut':
       return 'SOLD OUT'
     case 'Published':
-      return ticket_pricing.name
+      return description ?  description : ticket_pricing.name
     default:
       return null
     }


### PR DESCRIPTION
connects #644 

The "Ticket Name" is using `ticket_type.name`

The "Ticket Description" is now using `ticket_type.description` if it exists, and `ticket_type.ticket_pricing.name` if it doesnt.

