### PR TITLE
pre-load some event info

### DIFF
--- a/src/Events/details.js
+++ b/src/Events/details.js
@@ -67,7 +67,7 @@ export default class Details extends Component {
       event: {artists},
     } = this.props
 
-    if (artists.length === 0) {
+    if (!artists || artists.length === 0) {
       return null
     }
 

--- a/src/Events/index.js
+++ b/src/Events/index.js
@@ -79,7 +79,7 @@ function SuggestedSearches({searchText, events, navigate}) {
         renderItem={({item, separators}) => (
           <TouchableHighlight
             style={[styles.rowContainer, styles.paddingVerticalSmall]}
-            onPress={() => navigate('EventsShow', {eventId: item.id})}
+            onPress={() => navigate('EventsShow', {eventId: item.id, event: item})}
             onShowUnderlay={separators.highlight}
             onHideUnderlay={separators.unhighlight}
           >
@@ -276,7 +276,7 @@ export default class EventsIndex extends Component {
     return events.map((event, index) => (
       <EventItemView
         key={index}
-        onPress={() => navigate('EventsShow', {eventId: event.id})}
+        onPress={() => navigate('EventsShow', {eventId: event.id, event})}
         event={event}
         onInterested={toggleInterest}
       />

--- a/src/Events/routes.js
+++ b/src/Events/routes.js
@@ -18,6 +18,7 @@ const EventsShowRoute = {
   screen: EventsShow,
   navigationOptions: ({navigation}) => ({
     eventId: navigation.state.params.eventId,
+    event: navigation.state.params.event,
   }),
 }
 

--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -81,7 +81,7 @@ export default class EventShow extends Component {
     super(props)
 
     this.state = {
-      event: false,
+      event: props.navigation.getParam('event', false),
       eventId: props.navigation.getParam('eventId', false),
       favorite: false,
       currentScreen: 'details',
@@ -89,7 +89,6 @@ export default class EventShow extends Component {
       showSuccessModal: false,
       success: null,
     }
-    this.loadEvent()
   }
 
   componentWillReceiveProps(newProps) {
@@ -101,8 +100,7 @@ export default class EventShow extends Component {
       },
     } = newProps
 
-    // Do we want to check if the event id different, or just always update?
-    if (selectedEvent) {
+    if (selectedEvent.id && selectedEvent.id === this.state.eventId) {
       this.setState({event: selectedEvent})
     }
   }
@@ -117,12 +115,12 @@ export default class EventShow extends Component {
     this.scrollView.scrollTo({y: 10, x: 0, animated: true})
   }
 
-  clearEvent() {
+  async clearEvent() {
     const {
       screenProps: {store},
     } = this.props
 
-    store.clearEvent() // @TODO: Test this more - old events still in pop up.
+    store.clearEvent()
   }
 
   async loadEvent() {
@@ -239,7 +237,6 @@ export default class EventShow extends Component {
     }
 
     // @TODO: Add a ScrollTo initial position
-
     switch (currentScreen) {
     case 'details':
       return <Details event={event} onInterested={toggleInterest} />
@@ -470,8 +467,8 @@ export default class EventShow extends Component {
     return (
       <View style={{backgroundColor: 'white'}}>
         <NavigationEvents
-          onWillFocus={() => this.loadEvent()}
-          onDidBlur={() => this.clearEvent()}
+          onDidFocus={() => this.loadEvent()}
+          onWillBlur={() => this.clearEvent()}
         />
         <LoadingScreen visible={showLoadingModal} />
         <SuccessScreen visible={showSuccessModal} />


### PR DESCRIPTION
connects #645 

Passes the event info collected via events/index to pre-load events/show.

Events/show data is fetched in a non-blocking way to allow the event page to load quickly

Fixed a bug with clearEvent when exiting an event show page.