### PR TITLE
Add overflow to prevent white background on android

### DIFF
--- a/src/Tickets/Ticket.js
+++ b/src/Tickets/Ticket.js
@@ -183,12 +183,16 @@ export default class Ticket extends Component {
     if (activeTab === 'upcoming') {
       if (this.state.qrText) {
         return (
-          <QRCode
-            size={200}
-            fgColor="white"
-            bgColor="black"
-            value={this.state.qrText}
-          />
+          // https://github.com/cssivision/react-native-qrcode/issues/68
+          // Fix from https://github.com/cssivision/react-native-qrcode/issues/68#issuecomment-455791280
+          <View style={{overflow: 'hidden'}}>
+            <QRCode
+              size={200}
+              fgColor="white"
+              bgColor="black"
+              value={this.state.qrText}
+            />
+          </View>
         )
       } else {
         return (


### PR DESCRIPTION
connects to #657 

Bug on lib and work around: https://github.com/cssivision/react-native-qrcode/issues/68#issuecomment-455791280