### PR TITLE
Added the ability to accept promo codes

### DIFF
--- a/src/Events/checkout.js
+++ b/src/Events/checkout.js
@@ -125,7 +125,7 @@ export default class Checkout extends Component {
 
   render() {
     const {event, cart} = this.props
-    const {ticketsCents, feesCents, totalCents} = cart
+    const {ticketsCents, feesCents, discountCents, totalCents} = cart
     const eventTime = eventDateTimes(event.localized_times).event_start
 
     return (
@@ -225,6 +225,11 @@ export default class Checkout extends Component {
                 >
                   Sub Total
                 </Text>
+                {
+                  discountCents ? (
+                      <Text style={checkoutStyles.ticketHeader}>Discount</Text>
+                  ) : null
+                }
                 <Text style={checkoutStyles.ticketHeader}>Fees</Text>
               </View>
             </View>
@@ -238,6 +243,18 @@ export default class Checkout extends Component {
                 >
                   ${toDollars(ticketsCents)} USD
                 </Text>
+                {
+                  discountCents ? (
+                      <Text
+                          style={[
+                            checkoutStyles.ticketSubHeader,
+                            styles.marginBottomSmall,
+                          ]}
+                      >
+                        ${toDollars(discountCents)} USD
+                      </Text>
+                  ) : null
+                }
                 <Text style={checkoutStyles.ticketSubHeader}>
                   ${toDollars(feesCents)} USD
                 </Text>

--- a/src/Events/event_ticket.js
+++ b/src/Events/event_ticket.js
@@ -31,7 +31,6 @@ export class Ticket extends Component {
 
   get priceContent() {
     const {status, ticket_pricing} = this.props.ticket
-
     switch (status) {
     case 'SoldOut':
       return 'SOLD OUT'

--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -177,19 +177,28 @@ export default class EventShow extends Component {
     try {
       const response = await server.redemptionCodes.read({code})
       const {
-        data: {ticket_type},
+        data: {
+          //@deprecated
+          ticket_type,
+          ticket_types = []
+        },
       } = response
       const {event} = this.state
 
-      if (
-        !this.store.ticketTypeIds.includes(ticket_type.id) &&
-        ticket_type.event_id !== event.id
-      ) {
-        alert('This Promo Code is not valid for this event')
-        return
-      }
+      //This can be replaced by ticket_types once we are at parity with the server
+      const ticket_types_to_process = ticket_types.concat(ticket_type).filter(ticket_type => !!ticket_type)
+      ticket_types_to_process.forEach(ticket_type => {
+        if (
+            !this.store.ticketTypeIds.includes(ticket_type.id) &&
+            ticket_type.event_id !== event.id
+        ) {
+          alert('This Promo Code is not valid for this event')
+          return
+        }
 
-      this.store.replaceTicketType(ticket_type)
+        this.store.replaceTicketType(ticket_type)
+      })
+
     } catch (error) {
       apiErrorAlert(
         error,

--- a/src/state/cartStateProvider.js
+++ b/src/state/cartStateProvider.js
@@ -5,6 +5,10 @@ function itemIsTicket({item_type: type}) {
   return type === 'Tickets'
 }
 
+function itemIsDiscount({item_type: type}) {
+  return type === 'Discount'
+}
+
 function sumUnitPrices(items) {
   return items.reduce(
     (sum, {unit_price_in_cents: unitPrice, quantity}) =>
@@ -88,7 +92,11 @@ class CartContainer extends Container {
   }
 
   get fees() {
-    return this.items.filter((item) => !itemIsTicket(item))
+    return this.items.filter((item) => !itemIsTicket(item) && !itemIsDiscount(item))
+  }
+
+  get discounts() {
+    return this.items.filter(itemIsDiscount)
   }
 
   get selectedTicket() {
@@ -124,6 +132,10 @@ class CartContainer extends Container {
 
   get feesCents() {
     return sumUnitPrices(this.fees)
+  }
+
+  get discountCents() {
+    return sumUnitPrices(this.discounts);
   }
 
   get totalCents() {
@@ -174,7 +186,6 @@ class CartContainer extends Container {
   async _commitQuantity() {
     try {
       const response = await server.cart.replace(this.replaceParams)
-
       // set these first so we can calculate actual quantity
       await this.setState({response, isReady: true})
     } catch (error) {


### PR DESCRIPTION
This PR adds the check for promo codes. The new response type when adding a ticket from a hold or a promo code is an array of `ticket_type` named `ticket_types`. This PR re-uses the existing logic but loops through the array and applies the available holds / promo codes.

There is a new line item of `item_type` = `Discount` that needs to be catered for in the case of promo codes. Obviously this can be picked up and styled (making things look good is not my forte).

This requires bn-api to be at version 1.0.61 beta is there, production will be migrated tomorrow at about 09:00 UTC