### PR TITLE
Update API url endpoints

### DIFF
--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -2,10 +2,11 @@ import {Constants} from 'expo'
 
 const RELEASE_CHANNEL = Constants.manifest.releaseChannel || 'dev'
 const WEB_STAGING = 'https://beta.bigneon.com'
+const API_STAGING = 'https://api.staging.bigneon.com'
 const CLOUDINARY_CLOUD_STAGING = 'bigneon-dev'
 const CLOUDINARY_UPLOAD_PRESET_STAGING = 'dthcf8uc'
 const WEB_PRODUCTION = 'https://prod-1-mobile-www.bigneon.com'
-const API_PRODUCTION = 'https://api.bigneon.com'
+const API_PRODUCTION = 'https://api.production.bigneon.com'
 
 const SEGMENT_ANDROID_STAGING = 'juWgBzBtJX0DRiJLcw5UoGqFVZpiYi9j'
 const SEGMENT_IOS_STAGING = 'ew0hTJ9I33lME9Y9UNLAiAw4A9rjeyFV'
@@ -20,7 +21,7 @@ const dev = {
   ...defaultConfig,
   baseURL: WEB_STAGING,
   stripeFormURL: WEB_STAGING,
-  apiURL: `${WEB_STAGING}/api`,
+  apiURL: API_STAGING,
   timeout: 3000,
   cloudinaryCloud: CLOUDINARY_CLOUD_STAGING,
   cloudinaryUploadPreset: CLOUDINARY_UPLOAD_PRESET_STAGING,


### PR DESCRIPTION
The old endpoint is being deprecated.

```bash
curl -i https://api.production.bigneon.com/status
HTTP/2 200 
date: Tue, 30 Apr 2019 09:45:21 GMT
content-length: 0
access-control-allow-origin: *
access-control-expose-headers: x-app-version
vary: Origin
x-app-version: 1.0.76
```

```bash
 curl -i  https://api.staging.bigneon.com/status 
HTTP/2 200 
date: Tue, 30 Apr 2019 09:46:36 GMT
content-length: 0
access-control-allow-origin: *
access-control-expose-headers: x-app-version
vary: Origin
x-app-version: 1.0.84
```