### PR TITLE
added id to display for guest row content

### DIFF
--- a/src/Accounts/guest-list-checkin.js
+++ b/src/Accounts/guest-list-checkin.js
@@ -66,7 +66,7 @@ function GuestRowContent({guest}) {
         </View>
       </View>
       <Text style={doormanStyles.bodyText}>
-        {price(guest.price_in_cents)} | {guest.ticket_type}
+        {price(guest.price_in_cents)} | {guest.ticket_type} | {guest.id.slice(guest.id.length - 8)}
       </Text>
     </View>
   )


### PR DESCRIPTION
This PR adds the last 8 characters of the ticket id to the display in guest row content.   I have surmised that the guest.id string is the ticket id, want to confirm that is correct before merging.